### PR TITLE
Add static-check make target, github actions check, github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+For urgent operational issues, please contact AWS Support directly.
+https://aws.amazon.com/premiumsupport/
+
+For potential security issues, please do not post it in the Issues.
+Instead, please follow the instructions https://aws.amazon.com/security/vulnerability-reporting/ or email AWS security directly at aws-security@amazon.com.
+
+Please provide the following information:
+-->
+
+
+### Summary
+<!-- Please provide a brief outline of the issue -->
+
+
+### Description
+<!-- Provide detailed information about this issue -->
+
+
+
+<!-- Not required for feature requests -->
+### Expected Behavior
+
+
+### Observed Behavior
+
+
+### Environment Details
+<!--
+Examples:
+* docker info
+* curl http://localhost:51678/v1/metadata
+* df -h
+-->
+
+
+### Supporting Log Snippets
+<!--
+Please have a look at https://github.com/awslabs/ecs-logs-collector
+for the data we typically require for investigation
+
+Please note that GitHub issues are public, remove sensitive data from logs before posting.
+If you are not comfortable posting your logs here, please let us know and we
+can provide an alternate method.
+-->
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md
+
+Please provide the following information:
+-->
+
+### Summary
+<!-- What does this pull request do? -->
+
+### Implementation details
+<!-- How are the changes implemented? -->
+
+### Testing
+<!-- How was this tested? -->
+<!--
+Note for external contributors:
+`make test` and `make run-integ-tests` can run in a Linux development
+environment like your laptop.  `go test -timeout=30s ./agent/...` and
+`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
+like your laptop.  Please ensure unit and integration tests pass (on at least
+one platform) before opening the pull request.
+Once you open the pull request, there will be 14 automatic test checks on the bottom
+of the pull request, please make sure they all pass before you merge it. You can
+use `bot/test` label to rerun the automatic tests multiple times.
+-->
+
+New tests cover the changes: <!-- yes|no -->
+
+### Description for the changelog
+<!--
+Write a short (one line) summary that describes the changes in this
+pull request for inclusion in the changelog.
+You can see our changelog entry style here:
+https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
+-->
+
+### Licensing
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,10 @@
+name: Static Checks
+
+on: [pull_request]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make static-check

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 packer
 manifest.json
 overrides.auto.pkrvars.hcl
+shfmt
+shellcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## TBD

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 PACKER_VERSION := 1.7.4
-UNAME := $(shell uname -s)
-ifeq (${UNAME},Linux)
-	PACKER_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"
+KERNEL := $(shell uname -s | tr A-Z a-z)
+ARCH := $(shell uname -m)
+
+ifeq (${ARCH},aarch64)
+	ARCH_ALT=arm64
 endif
-ifeq (${UNAME},Darwin)
-	PACKER_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_darwin_amd64.zip"
+ifeq (${ARCH},x86_64)
+	ARCH_ALT=amd64
 endif
 
+PACKER_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_${KERNEL}_${ARCH_ALT}.zip"
+SHFMT_URL="https://github.com/mvdan/sh/releases/download/v3.4.0/shfmt_v3.4.0_${KERNEL}_${ARCH_ALT}"
+SHELLCHECK_URL="https://github.com/koalaman/shellcheck/releases/download/v0.7.2/shellcheck-v0.7.2.${KERNEL}.${ARCH}.tar.xz"
+
 packer:
-	curl ${PACKER_URL} -o ./packer.zip
+	curl -fLSs ${PACKER_URL} -o ./packer.zip
 	unzip ./packer.zip
 	rm ./packer.zip
 
@@ -20,16 +26,16 @@ release.auto.pkrvars.hcl:
 check-region:
 	@bash -c "if [ -z ${REGION} ]; then echo 'ERROR: REGION variable must be set. Example: \"REGION=us-west-2 make al2\"'; exit 1; fi"
 
-.PHONY: fmt
-fmt: packer
-	./packer fmt .
-
 .PHONY: init
-init: check-region packer
-	./packer init -var "region=${REGION}" .
+init: packer
+	./packer init .
+
+.PHONY: packer-fmt
+packer-fmt: packer
+	./packer fmt -check .
 
 .PHONY: validate
-validate: check-region packer
+validate: check-region init
 	./packer validate -var "region=${REGION}" .
 
 .PHONY: al1
@@ -52,6 +58,27 @@ al2gpu: check-region init validate release.auto.pkrvars.hcl
 al2inf: check-region init validate release.auto.pkrvars.hcl
 	./packer build -only="amazon-ebs.al2inf" -var "region=${REGION}" .
 
+shellcheck:
+	curl -fLSs ${SHELLCHECK_URL} -o /tmp/shellcheck.tar.xz
+	tar -xvf /tmp/shellcheck.tar.xz -C /tmp --strip-components=1
+	mv /tmp/shellcheck ./shellcheck
+	rm /tmp/shellcheck.tar.xz
+
+shfmt:
+	curl -fLSs ${SHFMT_URL} -o ./shfmt
+	chmod +x ./shfmt
+
+.PHONY: static-check
+static-check: packer-fmt shfmt shellcheck
+	REGION=us-west-2 make validate
+	./shfmt -d -s -w -i 4 ./scripts/*.sh
+	./shfmt -d -s -w -i 4 ./scripts/*/*.sh
+	./shellcheck --severity=error --exclude=SC2045 ./scripts/*.sh
+	./shellcheck --severity=error --exclude=SC2045 ./scripts/*/*.sh
+
 .PHONY: clean
 clean:
 	-rm manifest.json
+	-rm shellcheck
+	-rm shfmt
+	-rm packer

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -71,18 +71,6 @@ build {
     ]
   }
 
-  provisioner "file" {
-    source      = "files/repos/amzn2-extras.repo"
-    destination = "/tmp/amzn2-extras.repo"
-  }
-
-  provisioner "shell" {
-    inline_shebang = "/bin/sh -ex"
-    inline = [
-      "sudo mv /tmp/amzn2-extras.repo /etc/yum.repos.d/amzn2-extras.repo"
-    ]
-  }
-
   provisioner "shell" {
     inline_shebang = "/bin/sh -ex"
     inline = [
@@ -105,6 +93,20 @@ build {
   provisioner "shell" {
     script           = "scripts/install-docker.sh"
     environment_vars = ["DOCKER_VERSION=${var.docker_version}", "CONTAINERD_VERSION=${var.containerd_version}"]
+  }
+
+  # the ordering matters here, this repo is installed after docker is installed
+  # so that the docker extras repo is overwritten in the final AMI.
+  provisioner "file" {
+    source      = "files/repos/amzn2-extras.repo"
+    destination = "/tmp/amzn2-extras.repo"
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/sh -ex"
+    inline = [
+      "sudo mv /tmp/amzn2-extras.repo /etc/yum.repos.d/amzn2-extras.repo"
+    ]
   }
 
   provisioner "shell" {

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -69,18 +69,6 @@ build {
     ]
   }
 
-  provisioner "file" {
-    source      = "files/repos/amzn2-extras.repo"
-    destination = "/tmp/amzn2-extras.repo"
-  }
-
-  provisioner "shell" {
-    inline_shebang = "/bin/sh -ex"
-    inline = [
-      "sudo mv /tmp/amzn2-extras.repo /etc/yum.repos.d/amzn2-extras.repo"
-    ]
-  }
-
   provisioner "shell" {
     inline_shebang = "/bin/sh -ex"
     inline = [
@@ -107,6 +95,20 @@ build {
   provisioner "shell" {
     script           = "scripts/install-docker.sh"
     environment_vars = ["DOCKER_VERSION=${var.docker_version}", "CONTAINERD_VERSION=${var.containerd_version}"]
+  }
+
+  # the ordering matters here, this repo is installed after docker is installed
+  # so that the docker extras repo is overwritten in the final AMI.
+  provisioner "file" {
+    source      = "files/repos/amzn2-extras.repo"
+    destination = "/tmp/amzn2-extras.repo"
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/sh -ex"
+    inline = [
+      "sudo mv /tmp/amzn2-extras.repo /etc/yum.repos.d/amzn2-extras.repo"
+    ]
   }
 
   provisioner "shell" {

--- a/scripts/enable-ecs-agent-inferentia-support.sh
+++ b/scripts/enable-ecs-agent-inferentia-support.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-if [[ "$AMI_TYPE" != "al2inf" ]]; then
+if [[ $AMI_TYPE != "al2inf" ]]; then
     exit 0
 fi
 


### PR DESCRIPTION
*Description of changes:*

This adds a static check make target which checks that the packer files are all formatted (packer fmt), validated (packer validate), and that scripts are validated (shellcheck) and formatted (shfmt).

Also add that check as a github action that runs on every PR. Also have added PR and Issue templates from the aws/amazon-ecs-agent repo, and a CHANGELOG file.

Unrelatedly, move the amzn extras repo copy to run after the docker install.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
