### PR TITLE
Add AIR_GAPPED region support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,16 @@ shfmt:
 	curl -fLSs ${SHFMT_URL} -o ./shfmt
 	chmod +x ./shfmt
 
+.PHONY: fmt
+fmt: packer shfmt
+	./packer fmt .
+	./shfmt -l -s -w -i 4 ./*.sh ./*/*.sh ./*/*/*.sh
+
 .PHONY: static-check
 static-check: packer-fmt shfmt shellcheck
 	REGION=us-west-2 make validate
-	./shfmt -d -s -w -i 4 ./scripts/*.sh
-	./shfmt -d -s -w -i 4 ./scripts/*/*.sh
-	./shellcheck --severity=error --exclude=SC2045 ./scripts/*.sh
-	./shellcheck --severity=error --exclude=SC2045 ./scripts/*/*.sh
+	./shfmt -d -s -w -i 4 ./*.sh ./*/*.sh ./*/*/*.sh
+	./shellcheck --severity=error --exclude=SC2045 ./*.sh ./*/*.sh ./*/*/*.sh
 
 .PHONY: clean
 clean:

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -91,8 +91,12 @@ build {
   }
 
   provisioner "shell" {
-    script           = "scripts/install-docker.sh"
-    environment_vars = ["DOCKER_VERSION=${var.docker_version}", "CONTAINERD_VERSION=${var.containerd_version}"]
+    script = "scripts/install-docker.sh"
+    environment_vars = [
+      "DOCKER_VERSION=${var.docker_version}",
+      "CONTAINERD_VERSION=${var.containerd_version}",
+      "AIR_GAPPED=${var.air_gapped}"
+    ]
   }
 
   # the ordering matters here, this repo is installed after docker is installed
@@ -110,8 +114,14 @@ build {
   }
 
   provisioner "shell" {
-    script           = "scripts/install-ecs-init.sh"
-    environment_vars = ["REGION=${var.region}", "AGENT_VERSION=${var.ecs_agent_version}", "INIT_REV=${var.ecs_init_rev}", "AL_NAME=amzn2"]
+    script = "scripts/install-ecs-init.sh"
+    environment_vars = [
+      "REGION=${var.region}",
+      "AGENT_VERSION=${var.ecs_agent_version}",
+      "INIT_REV=${var.ecs_init_rev}",
+      "AL_NAME=amzn2",
+      "AIR_GAPPED=${var.air_gapped}"
+    ]
   }
 
   provisioner "shell" {
@@ -119,8 +129,12 @@ build {
   }
 
   provisioner "shell" {
-    script           = "scripts/install-exec-dependencies.sh"
-    environment_vars = ["REGION=${var.region}", "EXEC_SSM_VERSION=${var.exec_ssm_version}"]
+    script = "scripts/install-exec-dependencies.sh"
+    environment_vars = [
+      "REGION=${var.region}",
+      "EXEC_SSM_VERSION=${var.exec_ssm_version}",
+      "AIR_GAPPED=${var.air_gapped}"
+    ]
   }
 
   provisioner "shell" {

--- a/files/repos/amzn2-extras.repo
+++ b/files/repos/amzn2-extras.repo
@@ -7,7 +7,7 @@ gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2
 priority = 10
 skip_if_unavailable = 1
 report_instanceid = yes
- 
+
 [amzn2extra-ecs-debuginfo]
 enabled = 0
 name = Amazon Extras debuginfo repo for ecs
@@ -17,7 +17,7 @@ gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2
 priority = 10
 skip_if_unavailable = 1
 report_instanceid = yes
- 
+
 [amzn2extra-ecs]
 enabled = 1
 name = Amazon Extras repo for ecs

--- a/scripts/enable-services.sh
+++ b/scripts/enable-services.sh
@@ -3,3 +3,4 @@ set -ex
 
 sudo systemctl enable ecs
 sudo systemctl enable amazon-ecs-volume-plugin
+sudo systemctl enable amazon-ssm-agent

--- a/scripts/install-additional-packages.sh
+++ b/scripts/install-additional-packages.sh
@@ -4,6 +4,4 @@ set -ex
 ARCH=$(uname -m)
 
 # install any rpm packages from the additional-packages/ directory
-for rpm in $(ls /tmp/additional-packages/*."${ARCH}".rpm); do
-    sudo yum install -y "$rpm"
-done
+sudo yum localinstall -y /tmp/additional-packages/*."${ARCH}".rpm

--- a/scripts/install-docker.sh
+++ b/scripts/install-docker.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+if [ -n "$AIR_GAPPED" ]; then
+    echo "Air-gapped region, assuming docker and dependencies will be in additional-packages/ directory"
+    exit 0
+fi
+
 sudo amazon-linux-extras enable docker
 sudo yum install -y "docker-$DOCKER_VERSION" "containerd-$CONTAINERD_VERSION"

--- a/scripts/install-ecs-init.sh
+++ b/scripts/install-ecs-init.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
+if [ -n "$AIR_GAPPED" ]; then
+    echo "Air-gapped region, assuming ecs-init and dependencies will be in additional-packages/ directory"
+    exit 0
+fi
+
 WORK_DIR="$(mktemp -d)"
 trap "rm -rf ${WORK_DIR}" EXIT
 

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
+if [ -n "$AIR_GAPPED" ]; then
+    echo "Air-gapped region, exec feature is not supported"
+    exit 0
+fi
+
 BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${EXEC_SSM_VERSION}"
 CERTS_PATH="/var/lib/ecs/deps/execute-command/certs"
 ARCHITECTURE="$(uname -m)"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -81,3 +81,9 @@ variable "source_ami_al1" {
   type        = string
   description = "Amazon Linux 1 source AMI to build from."
 }
+
+variable "air_gapped" {
+  type        = string
+  description = "If this build is for an air-gapped region, set to 'true'"
+  default     = ""
+}


### PR DESCRIPTION
fixed the additional-packages install to do a yum "localinstall" on all
packages in the directory. Localinstall considers all rpm package files
together as if they are being installed from a repo, and will correctly
order the installation of the rpms if some of them have dependencies on
each other.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Adds support for air-gapped regions, which are not able to access public https endpoints, so must install all ECS dependencies from the `additional-packages/` directory.

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
