### PR TITLE
generate-release-vars: take ami_version as argument

### DIFF
--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -3,9 +3,9 @@ set -eio pipefail
 
 usage() {
     echo "Usage:"
-    echo "  $0 ECS_INIT_VERSION"
+    echo "  $0 ECS_INIT_VERSION AMI_VERSION"
     echo "Example:"
-    echo "  $0 1.55.0-1"
+    echo "  $0 1.55.0-1 20210902"
 }
 
 error() {
@@ -18,6 +18,10 @@ error() {
 readonly ecs_init_version="$1"
 if [ -z "$ecs_init_version" ]; then
     error "ecs-init version is required."
+fi
+readonly ami_version="$2"
+if [ -z "$ami_version" ]; then
+    error "ami version is required."
 fi
 
 agent_version=$(echo "$ecs_init_version" | awk -F "-" '{ print $1 }')
@@ -45,7 +49,7 @@ ami_name_al1=$(aws ec2 describe-images --region "$region" --owner amazon --image
 readonly ami_name_arm ami_name_x86 ami_name_al1
 
 cat >|release.auto.pkrvars.hcl <<EOF
-ami_version        = "$(date -d "+ 2 days" --utc +%Y%m%d)"
+ami_version        = "$ami_version"
 source_ami_al2     = "$ami_name_x86"
 source_ami_al2arm  = "$ami_name_arm"
 ecs_agent_version  = "$agent_version"

--- a/release.auto.pkrvars.hcl
+++ b/release.auto.pkrvars.hcl
@@ -1,7 +1,7 @@
 ami_version        = "20211106"
 source_ami_al2     = "amzn2-ami-minimal-hvm-2.0.20211005.0-x86_64-ebs"
 source_ami_al2arm  = "amzn2-ami-minimal-hvm-2.0.20211005.0-arm64-ebs"
-ecs_agent_version  = "1.56.0"
+ecs_agent_version  = "1.57.0"
 ecs_init_rev       = "1"
 docker_version     = "20.10.7"
 containerd_version = "1.4.6"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
