### PR TITLE
makefile fixup for m1 (arm) macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ PACKER_VERSION := 1.7.4
 KERNEL := $(shell uname -s | tr A-Z a-z)
 ARCH := $(shell uname -m)
 
+ifeq (${ARCH},arm64)
+	ARCH_ALT=arm64
+endif
 ifeq (${ARCH},aarch64)
 	ARCH_ALT=arm64
 endif


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

m1 (arm) macs return `arm64` from `uname -m`, rather than the linux standard of always returning `aarch64`

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

tested `make al2` on an m1 mac

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
