### PR TITLE
Add variable to specify url to install ecs-init from

### DIFF
--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -126,7 +126,8 @@ build {
       "AGENT_VERSION=${var.ecs_agent_version}",
       "INIT_REV=${var.ecs_init_rev}",
       "AL_NAME=amzn2",
-      "AIR_GAPPED=${var.air_gapped}"
+      "AIR_GAPPED=${var.air_gapped}",
+      "ECS_INIT_URL=${var.ecs_init_url_al2}"
     ]
   }
 

--- a/scripts/install-ecs-init.sh
+++ b/scripts/install-ecs-init.sh
@@ -143,15 +143,17 @@ qX2yy/UX5nSPU492e2CdZ1UhoU0SRFY3bxKHKB7SDbVeav+K5g==
 -----END PGP PUBLIC KEY BLOCK-----
 EOF
 
-ARCH=$(uname -m)
-
-host_suffix=""
-if grep -q "^cn-" <<<"$REGION"; then
-    host_suffix=".cn"
+if [ -z "$ECS_INIT_URL" ]; then
+    ARCH=$(uname -m)
+    host_suffix=""
+    if grep -q "^cn-" <<<"$REGION"; then
+        host_suffix=".cn"
+    fi
+    ECS_INIT_URL="https://s3.$REGION.amazonaws.com${host_suffix}/amazon-ecs-agent-$REGION/ecs-init-$AGENT_VERSION-$INIT_REV.$AL_NAME.$ARCH.rpm"
 fi
 
-curl -fLSs -o "$WORK_DIR/ecs-init.rpm" "https://s3.$REGION.amazonaws.com${host_suffix}/amazon-ecs-agent-$REGION/ecs-init-$AGENT_VERSION-$INIT_REV.$AL_NAME.$ARCH.rpm"
-curl -fLSs -o "$WORK_DIR/ecs-init.rpm.asc" "https://s3.$REGION.amazonaws.com${host_suffix}/amazon-ecs-agent-$REGION/ecs-init-$AGENT_VERSION-$INIT_REV.$AL_NAME.$ARCH.rpm.asc"
+curl -fLSs -o "$WORK_DIR/ecs-init.rpm" "$ECS_INIT_URL"
+curl -fLSs -o "$WORK_DIR/ecs-init.rpm.asc" "${ECS_INIT_URL}.asc"
 gpg --import "$WORK_DIR/amazon-ecs-agent.gpg"
 gpg --verify "$WORK_DIR/ecs-init.rpm.asc" "$WORK_DIR/ecs-init.rpm"
 

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -98,3 +98,9 @@ variable "air_gapped" {
   description = "If this build is for an air-gapped region, set to 'true'"
   default     = ""
 }
+
+variable "ecs_init_url_al2" {
+  type        = string
+  description = "Specify a particular ECS init URL to install. If empty it will use the standard path."
+  default     = ""
+}


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->

This variable allows users to specify their own al2 ecs-init install URL, to use instead of the standard path of:
```
"https://s3.$REGION.amazonaws.com${host_suffix}/amazon-ecs-agent-$REGION/ecs-init-$AGENT_VERSION-$INIT_REV.$AL_NAME.$ARCH.rpm"
```

The main purpose of this change is to enable us to build AMIs using alpha builds of the ecs-init package, so that we can test and qualify ecs-init working and running inside of an AMI.


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - Added support for building with a user-specified ecs-init URL

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
