### PR TITLE
Fix AL1 block device and docker storage setup

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -7,10 +7,16 @@ source "amazon-ebs" "al1" {
   ami_description = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version} x86_64 ECS HVM GP2"
   instance_type   = "c5.large"
   launch_block_device_mappings {
-    volume_size           = var.block_device_size_gb
+    volume_size           = 8
     delete_on_termination = true
     volume_type           = "gp2"
     device_name           = "/dev/xvda"
+  }
+  launch_block_device_mappings {
+    volume_size           = 22
+    delete_on_termination = true
+    volume_type           = "gp2"
+    device_name           = "/dev/xvdcz"
   }
   region = var.region
   source_ami_filter {

--- a/scripts/al1/configure-docker-storage-setup.sh
+++ b/scripts/al1/configure-docker-storage-setup.sh
@@ -22,6 +22,3 @@ LV_ERROR_WHEN_FULL=yes
 EXTRA_DOCKER_STORAGE_OPTIONS="--storage-opt dm.fs=ext4 --storage-opt dm.use_deferred_deletion=true"
 EOF
 sudo mv /tmp/docker-storage-setup /etc/sysconfig/docker-storage-setup
-
-sudo /usr/bin/docker-storage-setup
-

--- a/scripts/al1/configure-docker-storage-setup.sh
+++ b/scripts/al1/configure-docker-storage-setup.sh
@@ -22,3 +22,6 @@ LV_ERROR_WHEN_FULL=yes
 EXTRA_DOCKER_STORAGE_OPTIONS="--storage-opt dm.fs=ext4 --storage-opt dm.use_deferred_deletion=true"
 EOF
 sudo mv /tmp/docker-storage-setup /etc/sysconfig/docker-storage-setup
+
+sudo /usr/bin/docker-storage-setup
+


### PR DESCRIPTION
the docker-storage-setup binary sets up docker to use the devicemapper
storage driver. It expects a device named /dev/xvdcz to be present so
this device must be in the launch block device mappings in order for
this binary to run.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Internal functional test suite run on all AMIs with this change.



### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix - Fix AL1 recipe block device mapping and devicemapper docker-storage setup

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
