### PR TITLE
nvidia package install change to fix issue when running a yum update

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support.sh
+++ b/scripts/enable-ecs-agent-gpu-support.sh
@@ -30,8 +30,7 @@ sudo rm /etc/yum.repos.d/amzn2-nvidia-tmp.repo
 
 sudo yum install -y kernel-devel-$(uname -r) \
     system-release-nvidia \
-    nvidia-driver-latest-dkms \
-    kmod-nvidia-latest-dkms \
+    nvidia-fabric-manager \
     pciutils \
     xorg-x11-server-Xorg \
     docker-runtime-nvidia \
@@ -39,7 +38,7 @@ sudo yum install -y kernel-devel-$(uname -r) \
     libnvidia-container \
     libnvidia-container-tools \
     nvidia-container-runtime-hook \
-    cuda-drivers-fabricmanager \
+    cuda-drivers \
     cuda
 
 # The Fabric Manager service needs be started and enabled on EC2 P4d instances


### PR DESCRIPTION
### Summary
There are issues with the `cuda-drivers-fabricmanager` package that can cause errors when trying to `yum update`. This cr updates the nvidia packages we're installing to remove this package and use current required ones.

### Testing
Built ami with the changes in my own AWS account. Ran GPU functional tests with this ami. Tested on g4dn.2xlarge, p3.2xlarge, and p4d.24xlarge instances. 

New tests cover the changes: n/a

### Description for the changelog
nvidia package install change to fix issue when running a yum update

### Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
