### PR TITLE
Cleanup script fix

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -6,11 +6,11 @@ sudo yum clean all
 function cleanup() {
     FILES=("$@")
     for FILE in "${FILES[@]}"; do
-        if [[ -f $FILE ]]; then
+        if sudo test -f $FILE; then
             echo "Deleting $FILE"
             sudo shred -zuf $FILE
         fi
-        if [[ -f $FILE ]]; then
+        if sudo test -f $FILE; then
             echo "Failed to delete '$FILE'. Failing."
             exit 1
         fi
@@ -19,7 +19,6 @@ function cleanup() {
 
 # Clean up for cloud-init files
 CLOUD_INIT_FILES=(
-    "/etc/sudoers.d/90-cloud-init-users"
     "/etc/locale.conf"
     "/var/log/cloud-init.log"
     "/var/log/cloud-init-output.log"
@@ -68,7 +67,7 @@ for user in $USERS; do
     sudo find /home/"$user"/.ssh/authorized_keys -type f -exec shred -zuf {} \;
 done
 for user in $USERS; do
-    if [[ -f /home/"$user"/.ssh/authorized_keys ]]; then
+    if sudo test -f /home/"$user"/.ssh/authorized_keys; then
         echo Failed to delete /home/"$user"/.ssh/authorized_keys
         exit 1
     fi
@@ -110,11 +109,11 @@ if [[ $(sudo find /var/log/amazon/ssm -type f | sudo wc -l) -gt 0 ]]; then
     echo "Failed to delete /var/log/amazon/ssm"
     exit 1
 fi
-if [[ -d "/var/log/amazon/ssm" ]]; then
+if sudo test -d "/var/log/amazon/ssm"; then
     echo "Deleting /var/log/amazon/ssm/*"
     sudo rm -rf /var/log/amazon/ssm
 fi
-if [[ -d "/var/log/amazon/ssm" ]]; then
+if sudo test -d "/var/log/amazon/ssm"; then
     echo "Failed to delete /var/log/amazon/ssm"
     exit 1
 fi
@@ -152,7 +151,7 @@ fi
 
 # Shredding is not guaranteed to work well on rolling logs
 
-if [[ -f "/var/lib/rsyslog/imjournal.state" ]]; then
+if sudo test -f "/var/lib/rsyslog/imjournal.state"; then
     echo "Deleting /var/lib/rsyslog/imjournal.state"
     sudo shred -zuf /var/lib/rsyslog/imjournal.state
     sudo rm -f /var/lib/rsyslog/imjournal.state


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->

- the [[ -f ... ]] and [[ -d ... ]] checks are changed to use 'sudo test
  -f and sudo test -d'. This is so that we correctly detect files that
  are only readable by the root user.
- the cleanup script was leaving behind /root/.ssh/authorized_keys
  because it was not using 'sudo' to check for this file
- the cleanup script was previously also leaving behind
  /etc/sudoers.d/90-cloud-init-users, but we need this file for the
  ec2-user to have sudo access, so delete it from the list of files to
  delete from the AMI.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Created an AMI with this recipe, checked that build succeeds and `/root/.aws/authorized_keys` is deleted.

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

bugfix - delete /root/.aws/authorized_keys file on AMI build

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
