### PR TITLE
Delete neuron repo from inf AMI

### DIFF
--- a/scripts/enable-ecs-agent-inferentia-support.sh
+++ b/scripts/enable-ecs-agent-inferentia-support.sh
@@ -34,6 +34,9 @@ sudo yum install -y aws-neuron-runtime-base
 
 sudo yum install -y pciutils oci-add-hooks
 
+# disable neuron package upgrades by deleting the yum repo
+sudo rm /etc/yum.repos.d/neuron.repo
+
 NEURON_RUNTIME=/etc/docker-runtimes.d/neuron
 # Add env variable to identify if inf is supported on this ami
 mkdir -p /tmp/ecs


### PR DESCRIPTION
The neuron dkms packages have an issue with yum where they will remove
themselves after a package upgrade.

Anytime the neuron packages are upgraded they are liable to break any
customer who runs a "yum update" on the inferentia AMI.

This change deletes the neuron repo from yum, thereby disabling neuron
package upgrades on the inferentia AMI.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Built and run functional testing suite


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

bugfix: inferentia AMI: disable broken neuron package upgrades [#27](https://github.com/aws/amazon-ecs-ami/pull/27)

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
