### PR TITLE
Disable Amazon Linux 2022 motd, add ECS motd

### DIFF
--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -51,30 +51,8 @@ build {
     ]
   }
 
-  provisioner "file" {
-    source      = "files/29-ecs-banner-begin.sh.amzn2"
-    destination = "/tmp/29-ecs-banner-begin"
-  }
-
   provisioner "shell" {
-    inline_shebang = "/bin/sh -ex"
-    inline = [
-      "sudo mv /tmp/29-ecs-banner-begin /etc/update-motd.d/29-ecs-banner-begin",
-      "sudo chmod 755 /etc/update-motd.d/29-ecs-banner-begin"
-    ]
-  }
-
-  provisioner "file" {
-    source      = "files/31-ecs-banner-finish.sh.amzn2"
-    destination = "/tmp/31-ecs-banner-finish"
-  }
-
-  provisioner "shell" {
-    inline_shebang = "/bin/sh -ex"
-    inline = [
-      "sudo mv /tmp/31-ecs-banner-finish /etc/update-motd.d/31-ecs-banner-finish",
-      "sudo chmod 755 /etc/update-motd.d/31-ecs-banner-finish"
-    ]
+    script = "scripts/al2022/setup-motd.sh"
   }
 
   provisioner "shell" {

--- a/scripts/al2022/setup-motd.sh
+++ b/scripts/al2022/setup-motd.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -ex
+
+# AL2022 uses pam-motd, for docs see:
+# http://www.linux-pam.org/Linux-PAM-html/sag-pam_motd.html
+
+# disable the Amazon Linux motd banner (found at /usr/lib/motd.d/30-banner):
+sudo ln -s /dev/null /etc/motd.d/30-banner
+
+# add the ECS motd banner
+echo -e "
+   __|  __|  __|
+   _|  (   \__ \   Amazon Linux 2022 (ECS Optimized)
+ ____|\___|____/   Preview
+
+For documentation, visit http://aws.amazon.com/documentation/ecs" >/tmp/31-banner
+sudo mv /tmp/31-banner /etc/motd.d/31-banner


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

AL2022 uses pam-motd. This disables their banner (30-banner) and adds a new banner (31-banner) containing the ECS motd.

see http://www.linux-pam.org/Linux-PAM-html/sag-pam_motd.html for pam-motd docs

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

Tested AMI build, verified that ECS 2022 motd displays as expected:

```
% ssh ec2-user@XXX.XXX.XXX.XXX

   __|  __|  __|
   _|  (   \__ \   Amazon Linux 2022 (ECS Optimized)
 ____|\___|____/   Preview

For documentation, visit http://aws.amazon.com/documentation/ecs
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
