### PR TITLE
Add most_recent = true to source_ami_filter for all al flavors

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -23,7 +23,8 @@ source "amazon-ebs" "al1" {
     filters = {
       name = "${var.source_ami_al1}"
     }
-    owners = ["amazon"]
+    owners      = ["amazon"]
+    most_recent = true
   }
   user_data_file = "scripts/al1/user_data.sh"
   ssh_username   = "ec2-user"

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -17,7 +17,8 @@ source "amazon-ebs" "al2" {
     filters = {
       name = "${var.source_ami_al2}"
     }
-    owners = ["amazon"]
+    owners      = ["amazon"]
+    most_recent = true
   }
   ssh_username = "ec2-user"
   tags = {

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -17,7 +17,8 @@ source "amazon-ebs" "al2arm" {
     filters = {
       name = "${var.source_ami_al2arm}"
     }
-    owners = ["amazon"]
+    owners      = ["amazon"]
+    most_recent = true
   }
   ssh_username = "ec2-user"
   tags = {

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -17,7 +17,8 @@ source "amazon-ebs" "al2gpu" {
     filters = {
       name = "${var.source_ami_al2}"
     }
-    owners = ["amazon"]
+    owners      = ["amazon"]
+    most_recent = true
   }
   ssh_username = "ec2-user"
   tags = {

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -17,7 +17,8 @@ source "amazon-ebs" "al2inf" {
     filters = {
       name = "${var.source_ami_al2}"
     }
-    owners = ["amazon"]
+    owners      = ["amazon"]
+    most_recent = true
   }
   ssh_username = "ec2-user"
   tags = {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
AMIs with different ids can have the same name. When this is the case, packer will fail with: `amazon-ebs.al2: Your query returned more than one result. Please try a more specific search, or set most_recent to true.`

This PR fixes that by using `most_recent = true` config.

### Implementation details
<!-- How are the changes implemented? -->
Setting `most_recent = true` for [source_ami_filter](https://www.packer.io/plugins/builders/amazon/ebs#source_ami_filter) in all AL flavors.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

`make static-check`
New tests cover the changes: yes <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Enhancement - Set `most_recent = true` for `source_ami_filter` in order to avoid packer failures when duplicated AMIs exist.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
