### PR TITLE
[AL2022] Refactor ECS optimized AL2022 AMI building scripts - Part 2

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -10,7 +10,7 @@ packer {
 locals {
   packages_al1    = "amazon-efs-utils ec2-net-utils acpid irqbalance numactl rng-tools docker-storage-setup"
   packages_al2    = "amazon-efs-utils ec2-net-utils acpid amazon-ssm-agent yum-plugin-upgrade-helper"
-  packages_al2022 = "amazon-efs-utils"
+  packages_al2022 = "amazon-efs-utils amazon-ec2-net-utils acpid"
 }
 
 variable "ami_name_prefix_al2" {


### PR DESCRIPTION
### Summary
Changes in this PR contains
* Update `scripts/al2022/install-workarounds.sh` to get the latest release server. See the AL2022 version locking [here](https://docs.aws.amazon.com/linux/al2022/ug/version-locking.html).
* Install `amazon-ec2-net-utils` and `acpid` packages

### Implementation details
* scripts/al2022/install-workarounds.sh - get the latest releaseserver from `dnf check-release-update`
* variables.pkr.hcl - add `amazon-ec2-net-utils` and `acpid` to al2022

### Testing
* Built an AL2022 AMI, launched an EC2 instance, registered it to an ECS cluster, and ran a nginx task on the cluster successfully.
* Verified `amazon-ec2-net-utils` and `acpid` are installed on the container instance.
```
$ sudo dnf list installed | grep "ec2-net-utils"
amazon-ec2-net-utils.noarch            2.0.0-1.amzn2022                 @System      

$ sudo dnf list installed | grep "acpid"
acpid.x86_64                           2.0.32-4.amzn2022                @amazonlinux 
```
* Verify running `dnf check-release-update` on the container instance will not have any new release server return
* Same steps to test AL2022 ARM AMI 
  
New tests cover the changes: no

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
