### PR TITLE
update exec ssm agent version to 3.1.1260.0 and the sha256 checksums

### DIFF
--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -20,12 +20,12 @@ mkdir -p /tmp/ssm-binaries && cd /tmp/ssm-binaries
 case $ARCHITECTURE in
 'x86_64')
     curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
-    echo "299bfd3a20868906fda1af193dbabb6370986ba5d1f809313bdf425afd172111 ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
+    echo "068ceae7e0cf7cb096fbaed1b1341a7c6781b06e08659937823e9285c1963b6d ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
     sha256sum -c ./amazon-ssm-agent.tar.gz.sha256
     ;;
 'aarch64')
     curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
-    echo "d176d68fefa4b6ef9c09d59f4c7b5c3c08cdd25f358a68dd97610dbe423851ef ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
+    echo "33cbb5b970ecbe6559835936b76b337c28a9d5104c85fb80eb734128e90242a9 ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
     sha256sum -c ./amazon-ssm-agent.tar.gz.sha256
     ;;
 esac

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -63,7 +63,7 @@ variable "containerd_version" {
 
 variable "exec_ssm_version" {
   type        = string
-  default     = "3.1.804.0"
+  default     = "3.1.1260.0"
   description = "SSM binary version to build ECS exec support with."
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Updating exec SSM Agent version to 3.1.1260.0 and sha sums for the binaries.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Passed relevant function tests for AL1, 2, 2022

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update exec ssm agent version to 3.1.1260.0 and the sha256 checksums

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
