### PR TITLE
Fixed AL_NAME for AL2022 scripts

### DIFF
--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -100,7 +100,7 @@ build {
       "REGION=${var.region}",
       "AGENT_VERSION=${var.ecs_agent_version}",
       "INIT_REV=${var.ecs_init_rev}",
-      "AL_NAME=amzn2",
+      "AL_NAME=amzn2022",
       "ECS_INIT_URL=${var.ecs_init_url_al2022}",
       "AIR_GAPPED=${var.air_gapped}",
       "ECS_INIT_LOCAL_OVERRIDE=${var.ecs_init_local_override}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fixed `AL_NAME` variable for AL2022 build script so that it pulls the correct build of init rpm.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran `make al2022`, verified that the init url is correct, and the build was successful
```
==> amazon-ebs.al2022: + ECS_INIT_URL=https://s3.us-west-2.amazonaws.com/amazon-ecs-agent-us-west-2/ecs-init-1.61.0-1.amzn2022.x86_64.rpm

```

New tests cover the changes: no <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
