### PR TITLE
fixing variable `ami_name_al2_x86`  in generate-release-vars.sh

### DIFF
--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -61,7 +61,7 @@ ami_name_al2022_arm=$(aws ec2 describe-images --region "$region" --owner amazon 
 # Get the latest AL2022 distribution release
 distribution_release_al2022=$(curl "https://al2022-repos-us-west-2-9761ab97.s3.dualstack.us-west-2.amazonaws.com/core/releasemd.xml" | grep -o 'release version="[^"]*"' | cut -f2 -d '"' | sort -r | head -1)
 
-readonly ami_name_al2_arm ami_name_x86 ami_name_al1 ami_name_al2022_arm ami_name_al2022_x86 distribution_release_al2022
+readonly ami_name_al2_arm ami_name_al2_x86 ami_name_al1 ami_name_al2022_arm ami_name_al2022_x86 distribution_release_al2022
 
 cat >|release.auto.pkrvars.hcl <<EOF
 ami_version          = "$ami_version"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

fixing variable `ami_name_x86` -> `ami_name_al2_x86` in generate-release-vars.sh

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
fixing variable `ami_name_x86` -> `ami_name_al2_x86` in generate-release-vars.sh

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
