### PR TITLE
Recipe Changes for AL2022 Neuron Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ manifest.json
 overrides.auto.pkrvars.hcl
 shfmt
 shellcheck
+*.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ overrides.auto.pkrvars.hcl
 shfmt
 shellcheck
 *.idea
+*.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ al2022: check-region init validate release.auto.pkrvars.hcl
 al2022arm: check-region init validate release.auto.pkrvars.hcl
 	./packer build -only="amazon-ebs.al2022arm" -var "region=${REGION}" .
 
+.PHONY: al2022neu
+al2022neu: check-region init validate release.auto.pkrvars.hcl
+	./packer build -only="amazon-ebs.al2022neu" -var "region=${REGION}" .
+
 shellcheck:
 	curl -fLSs ${SHELLCHECK_URL} -o /tmp/shellcheck.tar.xz
 	tar -xvf /tmp/shellcheck.tar.xz -C /tmp --strip-components=1

--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -112,12 +112,8 @@ build {
     script = "scripts/append-efs-client-info.sh"
   }
 
-  ### neuron support packages not in AL2022 repos
   provisioner "shell" {
-    script = "scripts/al2022/install-neuron-packages.sh"
-    environment_vars = [
-      "AMI_TYPE=${source.name}"
-    ]
+    script = "scripts/install-additional-packages.sh"
   }
 
   ### exec

--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -112,6 +112,14 @@ build {
     script = "scripts/append-efs-client-info.sh"
   }
 
+  ### neuron support packages not in AL2022 repos
+  provisioner "shell" {
+    script = "scripts/al2022/install-neuron-packages.sh"
+    environment_vars = [
+      "AMI_TYPE=${source.name}"
+    ]
+  }
+
   ### exec
   provisioner "shell" {
     script = "scripts/install-exec-dependencies.sh"

--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -35,7 +35,8 @@ source "amazon-ebs" "al2022" {
 build {
   sources = [
     "source.amazon-ebs.al2022",
-    "source.amazon-ebs.al2022arm"
+    "source.amazon-ebs.al2022arm",
+    "source.amazon-ebs.al2022neu"
   ]
 
   provisioner "file" {
@@ -119,6 +120,13 @@ build {
       "EXEC_SSM_VERSION=${var.exec_ssm_version}",
       "AIR_GAPPED=${var.air_gapped}"
     ]
+  }
+
+  provisioner "shell" {
+    environment_vars = [
+      "AMI_TYPE=${source.name}"
+    ]
+    script = "scripts/enable-ecs-agent-inferentia-support.sh"
   }
 
   provisioner "shell" {

--- a/al2022neu.pkr.hcl
+++ b/al2022neu.pkr.hcl
@@ -1,5 +1,5 @@
 locals {
-  ami_name_al2022neu = "${var.ami_name_prefix_al2022}-neu-hvm-2022.0.${var.ami_version}-x86_64-ebs"
+  ami_name_al2022neu = "${var.ami_name_prefix_al2022}-neuron-hvm-2022.0.${var.ami_version}-x86_64-ebs"
 }
 
 source "amazon-ebs" "al2022neu" {

--- a/al2022neu.pkr.hcl
+++ b/al2022neu.pkr.hcl
@@ -1,0 +1,34 @@
+locals {
+  ami_name_al2022neu = "${var.ami_name_prefix_al2022}-neu-hvm-2022.0.${var.ami_version}-x86_64-ebs"
+}
+
+source "amazon-ebs" "al2022neu" {
+  ami_name        = "${local.ami_name_al2022neu}"
+  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM GP2"
+  instance_type   = "inf1.xlarge"
+  launch_block_device_mappings {
+    volume_size           = var.block_device_size_gb
+    delete_on_termination = true
+    volume_type           = "gp2"
+    device_name           = "/dev/xvda"
+  }
+  region = var.region
+  source_ami_filter {
+    filters = {
+      name = "${var.source_ami_al2022}"
+    }
+    owners      = ["amazon"]
+    most_recent = true
+  }
+  user_data_file = "scripts/al2022/user-data.sh"
+  ssh_username   = "ec2-user"
+  tags = {
+    os_version          = "Amazon Linux 2022"
+    source_image_name   = "{{ .SourceAMIName }}"
+    ecs_runtime_version = "Docker version ${var.docker_version_al2022}"
+    ecs_agent_version   = "${var.ecs_agent_version}"
+    ami_type            = "al2022neu"
+    ami_version         = "2022.0.${var.ami_version}"
+  }
+}
+

--- a/scripts/al2022/install-neuron-packages.sh
+++ b/scripts/al2022/install-neuron-packages.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -ex
-
-# install packages required by neuron but not in al2022 repos yet - dkms yum-plugin-dkms-build-requires oci-add-hooks
-# download them and put them under additional-packages/al2022
-if [[ $AMI_TYPE == "al2022neu" ]]; then
-    sudo yum localinstall -y /tmp/additional-packages/al2022/*.rpm
-fi

--- a/scripts/al2022/install-neuron-packages.sh
+++ b/scripts/al2022/install-neuron-packages.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -ex
+
+# install packages required by neuron but not in al2022 repos yet - dkms yum-plugin-dkms-build-requires oci-add-hooks
+# download them and put them under additional-packages/al2022
+if [[ $AMI_TYPE == "al2022neu" ]]; then
+    sudo yum localinstall -y /tmp/additional-packages/al2022/*.rpm
+fi

--- a/scripts/enable-ecs-agent-inferentia-support.sh
+++ b/scripts/enable-ecs-agent-inferentia-support.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-if [[ $AMI_TYPE != "al2inf" ]]; then
+if [[ $AMI_TYPE != "al2inf" && $AMI_TYPE != "al2022neu" ]]; then
     exit 0
 fi
 

--- a/scripts/install-additional-packages.sh
+++ b/scripts/install-additional-packages.sh
@@ -4,4 +4,11 @@ set -ex
 ARCH=$(uname -m)
 
 # install any rpm packages from the additional-packages/ directory
-sudo yum localinstall -y /tmp/additional-packages/*."${ARCH}".rpm
+if [[ $(sudo find /tmp/additional-packages/*."${ARCH}".rpm -type f | sudo wc -l) -gt 0 ]]; then
+    echo "Found additional packages with architecture ${ARCH} to be installed"
+    sudo yum localinstall -y /tmp/additional-packages/*."${ARCH}".rpm
+fi
+if [[ $(sudo find /tmp/additional-packages/*.noarch.rpm -type f | sudo wc -l) -gt 0 ]]; then
+    echo "Found additional packages with no specific architecture to be installed"
+    sudo yum localinstall -y /tmp/additional-packages/*.noarch.rpm
+fi

--- a/scripts/install-additional-packages.sh
+++ b/scripts/install-additional-packages.sh
@@ -4,11 +4,15 @@ set -ex
 ARCH=$(uname -m)
 
 # install any rpm packages from the additional-packages/ directory
-if [[ $(sudo find /tmp/additional-packages/*."${ARCH}".rpm -type f | sudo wc -l) -gt 0 ]]; then
+if ls /tmp/additional-packages/*."${ARCH}".rpm; then
     echo "Found additional packages with architecture ${ARCH} to be installed"
     sudo yum localinstall -y /tmp/additional-packages/*."${ARCH}".rpm
+else
+    echo "No matching additional packages with architecture ${ARCH} found"
 fi
-if [[ $(sudo find /tmp/additional-packages/*.noarch.rpm -type f | sudo wc -l) -gt 0 ]]; then
+if ls /tmp/additional-packages/*.noarch.rpm; then
     echo "Found additional packages with no specific architecture to be installed"
     sudo yum localinstall -y /tmp/additional-packages/*.noarch.rpm
+else
+    echo "No matching additional packages with no architecture found"
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds a new build target - `al2022neu`, and adds `scripts/enable-ecs-agent-inferentia-support.sh` to AL2022 recipes.

### Implementation details
<!-- How are the changes implemented? -->
* Add new target to Makefile
* Modify `al2022.pkr.hcl` build sources to include `al2022neu`, as well as two provisioners to
  * run `scripts/enable-ecs-agent-inferentia-support.sh` to install neuron packages on AL2022 base instance and enable `INF` on instance.
  * install necessary neuron packages that is not in AL2022 Repo yet in `install-neuron-packages.sh` (missed packages can be found in `scripts/al2022/install-neuron-packages.sh`). Downloaded AL2 version of those rpms and put them under `amazon-ecs-ami/additional-packages/al2022`
* Create `al2022neu.pkr.hcl` and `scripts/al2022/install-neuron-packages.sh`
* Modify `scripts/enable-ecs-agent-inferentia-support.sh` to also run when `AMI_TYPE` is `al2022neu` 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
New tests cover the changes: <!-- yes|no --> No

Manual Tests:
Ran `REGION=us-west-2 make al2022neu` and successfully created an AMI (ami-056e2478617a095b7 in personal test account) with name `unofficial-amzn2022-ami-ecs-neu-hvm-2022.0.20220520-x86_64-ebs`

Launched an INF instance with this AMI and ran a busybox task on this instance.


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Recipe changes for AL2022 Neuron Support

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
