### PR TITLE
Changed all AMIs to use gp3 vols

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -4,18 +4,18 @@ locals {
 
 source "amazon-ebs" "al1" {
   ami_name        = "${local.ami_name_al1}"
-  ami_description = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version} x86_64 ECS HVM GP3"
   instance_type   = "c5.large"
   launch_block_device_mappings {
     volume_size           = 8
     delete_on_termination = true
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     device_name           = "/dev/xvda"
   }
   launch_block_device_mappings {
     volume_size           = 22
     delete_on_termination = true
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     device_name           = "/dev/xvdcz"
   }
   region = var.region

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -4,12 +4,12 @@ locals {
 
 source "amazon-ebs" "al2" {
   ami_name        = "${local.ami_name_al2}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP3"
   instance_type   = "c5.large"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     device_name           = "/dev/xvda"
   }
   region = var.region

--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -4,12 +4,12 @@ locals {
 
 source "amazon-ebs" "al2022" {
   ami_name        = "${local.ami_name_al2022}"
-  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM GP3"
   instance_type   = "c5.large"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     device_name           = "/dev/xvda"
   }
   region = var.region

--- a/al2022arm.pkr.hcl
+++ b/al2022arm.pkr.hcl
@@ -4,12 +4,12 @@ locals {
 
 source "amazon-ebs" "al2022arm" {
   ami_name        = "${local.ami_name_al2022arm}"
-  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} arm64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} arm64 ECS HVM GP3"
   instance_type   = "m6g.xlarge"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     device_name           = "/dev/xvda"
   }
   region = var.region

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -4,12 +4,12 @@ locals {
 
 source "amazon-ebs" "al2arm" {
   ami_name        = "${local.ami_name_al2arm}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} arm64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} arm64 ECS HVM GP3"
   instance_type   = "m6g.xlarge"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     device_name           = "/dev/xvda"
   }
   region = var.region

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -4,12 +4,12 @@ locals {
 
 source "amazon-ebs" "al2gpu" {
   ami_name        = "${local.ami_name_al2gpu}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP3"
   instance_type   = "c5.4xlarge"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     device_name           = "/dev/xvda"
   }
   region = var.region

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -4,12 +4,12 @@ locals {
 
 source "amazon-ebs" "al2inf" {
   ami_name        = "${local.ami_name_al2inf}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP3"
   instance_type   = "inf1.xlarge"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     device_name           = "/dev/xvda"
   }
   region = var.region

--- a/scripts/al1/configure-docker-storage-setup.sh
+++ b/scripts/al1/configure-docker-storage-setup.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # ECS-optimized AMIs are provisioned with two disks:
-# 1) Root volume at /dev/sda (GP2, 8GB, delete on terminate)
-# 2) Extra EBS volume at /dev/xvdcz just for Docker (GP2, 22GB, delete on terminate)
+# 1) Root volume at /dev/sda (GP3, 8GB, delete on terminate)
+# 2) Extra EBS volume at /dev/xvdcz just for Docker (GP3, 22GB, delete on terminate)
 #
 # We use docker-storage-setup to configure this additional device properly.
 # By default docker-storage-setup will configure 40% of the device, and will


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
 Create AMIs with gp3 EBS volumes instead of gp2
### Implementation details
<!-- How are the changes implemented? -->
Changed vol type in .hcl files
### Testing
<!-- How was this tested? -->
There are no makefile targets named `test` or `run-integ-tests`, nor is there a `.\scripts\run-integ-tests.ps1`. I am not sure how to perform automated testing. Created al2 and al2arm AMIs and they looked fine. 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Use gp3 volumes
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
