### PR TITLE
Reboot AMI builder worker instance to install kernel update before installing neuron packages for AL2022

### DIFF
--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -136,8 +136,10 @@ build {
     environment_vars = [
       "AMI_TYPE=${source.name}"
     ]
-    pause_before = "60s" # pause for the reboot
-    script       = "scripts/enable-ecs-agent-inferentia-support.sh"
+    pause_before        = "1s" # pause for starting the reboot
+    start_retry_timeout = "1s" # wait before start retry
+    max_retries         = 30
+    script              = "scripts/enable-ecs-agent-inferentia-support.sh"
   }
 
   provisioner "shell" {

--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -122,11 +122,22 @@ build {
     ]
   }
 
+  ### reboot worker instance to install kernel update. enable-ecs-agent-inferentia-support needs
+  ### new kernel (if there is) to be installed.
+  provisioner "shell" {
+    inline_shebang    = "/bin/sh -ex"
+    expect_disconnect = "true"
+    inline = [
+      "sudo reboot"
+    ]
+  }
+
   provisioner "shell" {
     environment_vars = [
       "AMI_TYPE=${source.name}"
     ]
-    script = "scripts/enable-ecs-agent-inferentia-support.sh"
+    pause_before = "60s" # pause for the reboot
+    script       = "scripts/enable-ecs-agent-inferentia-support.sh"
   }
 
   provisioner "shell" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add a reboot before installing neuron packages for AL2022. Add a 60s wait for reboot.

For AL2022, since base AMI and distribution release version can be different for our AMI build process, there can potentially be a kernel update when we run `sudo dnf update -y --releasever=2022.0.20220831`. However, kernel update will not be installed without a reboot. Therefore, `uname -r` value which is used by `enable-ecs-agent-inferentia-support` script, will not be updated. When launching a new instance the kernel update will be installed, causing the neuron driver installed by `enable-ecs-agent-inferentia-support` script to not work, due to `neuron.ko` is installed in the legacy kernel version's directory.

Example:
```
sudo insmod /lib/modules/$(uname -r)/extra/neuron.ko
insmod: ERROR: could not load module /lib/modules/5.15.57-30.131.amzn2022.x86_64/extra/neuron.ko: No such file or directory
```
there are actually two directories under /lib/modules
```
5.15.57-29.131.amzn2022.x86_64/
5.15.57-30.131.amzn2022.x86_64/
```
and `neuron.ko` is under `lib/modules/5.15.57-29.131.amzn2022.x86_64/extra/`


### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
Tried build a new AMI with this change, and found /dev/neuron0 on instance launched with this new AMI.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
