### PR TITLE
Update to Exec SSM Agent version 3.1.1732.0

### DIFF
--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -20,12 +20,12 @@ mkdir -p /tmp/ssm-binaries && cd /tmp/ssm-binaries
 case $ARCHITECTURE in
 'x86_64')
     curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
-    echo "068ceae7e0cf7cb096fbaed1b1341a7c6781b06e08659937823e9285c1963b6d ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
+    echo "0100e5f6299274150d9252eb56ace6f3ff797ee2e9c17be1d6b9b8035b75315c ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
     sha256sum -c ./amazon-ssm-agent.tar.gz.sha256
     ;;
 'aarch64')
     curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
-    echo "33cbb5b970ecbe6559835936b76b337c28a9d5104c85fb80eb734128e90242a9 ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
+    echo "2f345a98ed25a9ffeb12355533b242110a502c929dd3abd61c2936000d22f230 ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
     sha256sum -c ./amazon-ssm-agent.tar.gz.sha256
     ;;
 esac

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -75,7 +75,7 @@ variable "containerd_version_al2022" {
 
 variable "exec_ssm_version" {
   type        = string
-  default     = "3.1.1260.0"
+  default     = "3.1.1732.0"
   description = "SSM binary version to build ECS exec support with."
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* Update SSM Agent binary version used for exec to ```3.1.1732.0```
* Update sha256 checksums

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Made custom AMIs with the this change and verified all Exec checks pass

New tests cover the changes: <!-- yes|no --> No new checks

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update to Exec SSM Agent version 3.1.1732.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
