### PR TITLE
Install Appnet Agent from AL repo; disable userland-proxy for docker

### DIFF
--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -175,6 +175,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/install-service-connect-appnet.sh"
+  }
+
+  provisioner "shell" {
     script = "scripts/cleanup.sh"
   }
 

--- a/scripts/install-docker.sh
+++ b/scripts/install-docker.sh
@@ -12,3 +12,15 @@ if command -v amazon-linux-extras; then
 fi
 
 sudo yum install -y "docker-$DOCKER_VERSION" "containerd-$CONTAINERD_VERSION"
+
+# disable userland-proxy for docker
+WORK_DIR="$(mktemp -d)"
+trap "rm -rf ${WORK_DIR}" EXIT
+
+cat >"$WORK_DIR/docker-daemon-config.json" <<EOF
+{
+    "userland-proxy": false
+}
+EOF
+
+sudo mkdir -p /etc/docker && sudo mv "$WORK_DIR/docker-daemon-config.json" /etc/docker/daemon.json

--- a/scripts/install-service-connect-appnet.sh
+++ b/scripts/install-service-connect-appnet.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+
+sudo yum install -y ecs-service-connect-agent


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR includes changes to 
1. Install Appnet agent required during AMI build for al2. Appnet Agent rpm is not available for al2022 yet.
2. Disable userland-proxy for docker to avoid using up host ephemeral ports when client and server are colocated on host for SC bridge mode.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
Tested the changes manually by building a new AMI and confirmed that
1. Agent successfully loaded the Appnet tarball for the expected filepath
2. `userland-proxy` config disabled in /etc/docker/daemon.json
3.  Was able to run SC task in bridge mode successfully and see that Appnet agent and Appnet relay containers were running.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
