### PR TITLE
Use the latest AL2022 release server

### DIFF
--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -66,7 +66,7 @@ build {
   provisioner "shell" {
     inline_shebang = "/bin/sh -ex"
     inline = [
-      "sudo dnf update -y --releasever=${var.distribution_release_al2022}"
+      "sudo dnf update -y --releasever=latest"
     ]
   }
 

--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -60,11 +60,7 @@ ami_id_al2022_arm=$(aws ec2 describe-images --region "$region" --owners amazon -
 ami_name_al2022_arm=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2022_arm" --query 'Images[0].Name' --output text)
 kernel_version_al2022_arm=$(grep -o -e "-kernel-[1-9.]*" <<<"$ami_name_al2022_arm")
 
-# Get the latest AL2022 distribution release
-# xmllint is required to find the latest distribution release from releasemd.xml in us-west-2
-distribution_release_al2022=$(curl -s https://al2022-repos-us-west-2-9761ab97.s3.dualstack.us-west-2.amazonaws.com/core/releasemd.xml | xmllint --xpath "string(//root/releases/release[last()]/@version)" -)
-
-readonly ami_name_al2_arm ami_name_al2_x86 ami_name_al1 ami_name_al2022_arm ami_name_al2022_x86 distribution_release_al2022
+readonly ami_name_al2_arm ami_name_al2_x86 ami_name_al1 ami_name_al2022_arm ami_name_al2022_x86
 
 cat >|release.auto.pkrvars.hcl <<EOF
 ami_version          = "$ami_version"
@@ -79,5 +75,4 @@ source_ami_al2022    = "$ami_name_al2022_x86"
 source_ami_al2022arm = "$ami_name_al2022_arm"
 kernel_version_al2022    = "$kernel_version_al2022_x86"
 kernel_version_al2022arm = "$kernel_version_al2022_arm"
-distribution_release_al2022  = "$distribution_release_al2022"
 EOF

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -99,11 +99,6 @@ variable "source_ami_al2022arm" {
   description = "Amazon Linux 2022 ARM source AMI to build from."
 }
 
-variable "distribution_release_al2022" {
-  type        = string
-  description = "Amazon Linux 2022 distribution release."
-}
-
 variable "kernel_version_al2022" {
   type        = string
   description = "Amazon Linux 2022 kernel version."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Remove `distribution_release_al2022`  and use `latest` get the latest AL2022 repository version.

### Implementation details
1. Remove `distribution_release_al2022` from generate-release-vars.sh and variables.pkr.hcl
2. Use `latest` for `sudo dnf update -y --releasever=latest` in al2022.pkr.hcl

### Testing
#### Test case 1: Using the latest Amazon Linux AL2022 (20221101) as source AMI
1. Generated the new release variables
```
ami_version          = "99999999"
ecs_agent_version    = "1.65.0"
ecs_init_rev         = "1"
docker_version       = "20.10.13"
containerd_version   = "1.4.13"
source_ami_al2022    = "al2022-ami-minimal-2022.0.20221101.0-kernel-5.15-x86_64"
source_ami_al2022arm = "al2022-ami-minimal-2022.0.20221101.0-kernel-5.15-arm64"
...
```
2. Built AL2022 with the generated release variables using the source AMI `al2022-ami-minimal-2022.0.20221101.0-kernel-5.15-x86_64`, and the build is completed successfully.
```
==> amazon-ebs.al2022: + sudo dnf update -y --releasever=latest
    amazon-ebs.al2022: Waiting for process with pid 1602 to finish.
    amazon-ebs.al2022: Amazon Linux 2022 repository                     24 MB/s |  17 MB     00:00
    amazon-ebs.al2022: Dependencies resolved.
    amazon-ebs.al2022: Nothing to do.
    amazon-ebs.al2022: Complete!
```
#### Test case 2: Using the previous Amazon Linux AL2022 (20221019) as source AMI
1. Generated the new release variables
```
ami_version                 = "88888888"
ecs_agent_version           = "1.65.0"
ecs_init_rev                = "1"
docker_version              = "20.10.17"
containerd_version          = "1.6.6"
source_ami_al2022           = "al2022-ami-minimal-2022.0.20221019.4-kernel-5.15-x86_64"
source_ami_al2022arm        = "al2022-ami-minimal-2022.0.20221019.4-kernel-5.15-arm64"
...
```
2. Built AL2022 with the generated release variables using the source AMI `al2022-ami-minimal-2022.0.20221019.4-kernel-5.15-x86_64`, and the build is completed successfully.
```
==> amazon-ebs.al2022: + sudo dnf update -y --releasever=latest
    amazon-ebs.al2022: Amazon Linux 2022 repository                     23 MB/s |  17 MB     00:00
    amazon-ebs.al2022: Last metadata expiration check: 0:00:06 ago on Tue 01 Nov 2022 09:14:15 PM UTC.
    amazon-ebs.al2022: Dependencies resolved.
    amazon-ebs.al2022: ================================================================================
    amazon-ebs.al2022:  Package               Arch    Version                       Repository    Size
    amazon-ebs.al2022: ================================================================================
    amazon-ebs.al2022: Upgrading:
    ...
    amazon-ebs.al2022: Upgraded:
    amazon-ebs.al2022:   amazon-linux-repo-s3-2022.0.20221101-0.amzn2022.noarch
    amazon-ebs.al2022:   openssl-1:3.0.5-1.amzn2022.0.3.x86_64
    amazon-ebs.al2022:   openssl-libs-1:3.0.5-1.amzn2022.0.3.x86_64
    amazon-ebs.al2022:   system-release-2022.0.20221101-0.amzn2022.noarch
    amazon-ebs.al2022:
    amazon-ebs.al2022: Complete!
```
New tests cover the changes: no

### Description for the changelog
Use "latest" to get the latest AL2022 repository version

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
