### PR TITLE
Add back oci-add-hooks to neuron recipe (AL2INF only)

### DIFF
--- a/scripts/enable-ecs-agent-inferentia-support.sh
+++ b/scripts/enable-ecs-agent-inferentia-support.sh
@@ -30,6 +30,12 @@ sudo yum install kernel-devel-$(uname -r) kernel-headers-$(uname -r) -y
 sudo yum install -y aws-neuronx-dkms-2.*
 sudo yum install -y aws-neuronx-oci-hook-2.*
 
+# Install oci-add-hooks
+# TODO: oci-add-hooks package has compatibility issue with AL2022 IMDSv2. Remove condition after root caused and resolved
+if [[ $AMI_TYPE == "al2inf" ]]; then
+    sudo yum install -y oci-add-hooks
+fi
+
 # Install Neuron Tools
 # TODO: use aws-neuronx-tools on al2inf when it is ready
 if [[ $AMI_TYPE == "al2inf" ]]; then # drop this dependency for AL2022 or later AMIs


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Previously when we upgrade to neuron v2 we removed `oci-add-hooks`. This needs to be added back. However, this package seems cause compatibility issue on AL2022 after IMDS v2 is enabled. To keep inferentia/neuron image and GPU image the same, adding this back to AL2 first and after we root cause the issue and resolve it we add it to AL2022 Neuron image.

### Implementation details
<!-- How are the changes implemented? -->
Update `enable-ecs-agent-inferentia-support.sh` script.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Test AMI successfully built (in ci-prod account):
inf: ami-09d49f099bf4807ba
neu(with oci-add-hooks package): ami-0c6d60295213e8058
neu(without oci-add-hooks package): ami-02f9c3162bf307a0f

Run functional test (MACIS) on 
* ami-09d49f099bf4807ba: Pass
* ami-0c6d60295213e8058:  EFS tests and IMDSv2 tests Failed
* ami-02f9c3162bf307a0f: Pass

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
