### PR TITLE
userland-proxy should be enabled by default

### DIFF
--- a/scripts/install-docker.sh
+++ b/scripts/install-docker.sh
@@ -12,15 +12,3 @@ if command -v amazon-linux-extras; then
 fi
 
 sudo yum install -y "docker-$DOCKER_VERSION" "containerd-$CONTAINERD_VERSION"
-
-# disable userland-proxy for docker
-WORK_DIR="$(mktemp -d)"
-trap "rm -rf ${WORK_DIR}" EXIT
-
-cat >"$WORK_DIR/docker-daemon-config.json" <<EOF
-{
-    "userland-proxy": false
-}
-EOF
-
-sudo mkdir -p /etc/docker && sudo mv "$WORK_DIR/docker-daemon-config.json" /etc/docker/daemon.json


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Reverting the change to disable userland proxy

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
