### PR TITLE
Remove AL2022 user-data ssh access workaround

### DIFF
--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -20,8 +20,7 @@ source "amazon-ebs" "al2022" {
     owners      = ["amazon"]
     most_recent = true
   }
-  user_data_file = "scripts/al2022/user-data.sh"
-  ssh_username   = "ec2-user"
+  ssh_username = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2022"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2022arm.pkr.hcl
+++ b/al2022arm.pkr.hcl
@@ -20,8 +20,7 @@ source "amazon-ebs" "al2022arm" {
     owners      = ["amazon"]
     most_recent = true
   }
-  user_data_file = "scripts/al2022/user-data.sh"
-  ssh_username   = "ec2-user"
+  ssh_username = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2022"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2022neu.pkr.hcl
+++ b/al2022neu.pkr.hcl
@@ -20,8 +20,7 @@ source "amazon-ebs" "al2022neu" {
     owners      = ["amazon"]
     most_recent = true
   }
-  user_data_file = "scripts/al2022/user-data.sh"
-  ssh_username   = "ec2-user"
+  ssh_username = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2022"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/scripts/al2022/user-data.sh
+++ b/scripts/al2022/user-data.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# https://github.com/hashicorp/packer/issues/10074#issuecomment-886137013
-sudo sed -i -r -e \
-    's/^(PubkeyAcceptedKeyTypes )(.*)/\1ssh-rsa,\2/' \
-    /etc/crypto-policies/back-ends/opensshserver.config
-
-sudo systemctl restart sshd


### PR DESCRIPTION
This was added to workaround a bug in the packer amazon plugin: https://github.com/hashicorp/packer-plugin-amazon/issues/172

The bug was fixed in plugin version 1.0.8, and we have now internally migrated to plugin 1.1.5, so we no longer need the workaround.

External users can run `packer init -upgrade` to upgrade their packer plugin versions if they still see this bug locally.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

AL2022 builds was tested locally and in internal build pipelines 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement - Remove AL2022 user-data ssh access workaround

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
