### PR TITLE
Use spot_instance_types for building AMIs

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al1" {
-  ami_name        = "${local.ami_name_al1}"
-  ami_description = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version} x86_64 ECS HVM GP2"
-  instance_type   = "c5.large"
+  ami_name            = "${local.ami_name_al1}"
+  ami_description     = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version} x86_64 ECS HVM GP2"
+  spot_instance_types = var.general_purpose_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = 8
     delete_on_termination = true
@@ -27,6 +28,7 @@ source "amazon-ebs" "al1" {
     most_recent = true
   }
   user_data_file = "scripts/al1/user_data.sh"
+  ssh_interface  = "public_ip"
   ssh_username   = "ec2-user"
   tags = {
     os_version          = "Amazon Linux"

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al2" {
-  ami_name        = "${local.ami_name_al2}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
-  instance_type   = "c5.large"
+  ami_name            = "${local.ami_name_al2}"
+  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  spot_instance_types = var.general_purpose_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
@@ -20,7 +21,8 @@ source "amazon-ebs" "al2" {
     owners      = ["amazon"]
     most_recent = true
   }
-  ssh_username = "ec2-user"
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al2022" {
-  ami_name        = "${local.ami_name_al2022}"
-  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM EBS"
-  instance_type   = "c5.large"
+  ami_name            = "${local.ami_name_al2022}"
+  ami_description     = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM EBS"
+  spot_instance_types = var.general_purpose_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
@@ -20,7 +21,8 @@ source "amazon-ebs" "al2022" {
     owners      = ["amazon"]
     most_recent = true
   }
-  ssh_username = "ec2-user"
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2022"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2022arm.pkr.hcl
+++ b/al2022arm.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al2022arm" {
-  ami_name        = "${local.ami_name_al2022arm}"
-  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} arm64 ECS HVM EBS"
-  instance_type   = "m6g.xlarge"
+  ami_name            = "${local.ami_name_al2022arm}"
+  ami_description     = "Amazon Linux AMI 2022.0.${var.ami_version} arm64 ECS HVM EBS"
+  spot_instance_types = var.arm_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
@@ -20,7 +21,8 @@ source "amazon-ebs" "al2022arm" {
     owners      = ["amazon"]
     most_recent = true
   }
-  ssh_username = "ec2-user"
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2022"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2022neu.pkr.hcl
+++ b/al2022neu.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al2022neu" {
-  ami_name        = "${local.ami_name_al2022neu}"
-  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM EBS"
-  instance_type   = "inf1.xlarge"
+  ami_name            = "${local.ami_name_al2022neu}"
+  ami_description     = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM EBS"
+  spot_instance_types = var.neu_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
@@ -20,7 +21,8 @@ source "amazon-ebs" "al2022neu" {
     owners      = ["amazon"]
     most_recent = true
   }
-  ssh_username = "ec2-user"
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2022"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al2arm" {
-  ami_name        = "${local.ami_name_al2arm}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} arm64 ECS HVM GP2"
-  instance_type   = "m6g.xlarge"
+  ami_name            = "${local.ami_name_al2arm}"
+  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} arm64 ECS HVM GP2"
+  spot_instance_types = var.arm_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
@@ -20,7 +21,8 @@ source "amazon-ebs" "al2arm" {
     owners      = ["amazon"]
     most_recent = true
   }
-  ssh_username = "ec2-user"
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al2gpu" {
-  ami_name        = "${local.ami_name_al2gpu}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
-  instance_type   = "c5.4xlarge"
+  ami_name            = "${local.ami_name_al2gpu}"
+  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  spot_instance_types = var.gpu_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
@@ -20,7 +21,8 @@ source "amazon-ebs" "al2gpu" {
     owners      = ["amazon"]
     most_recent = true
   }
-  ssh_username = "ec2-user"
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al2inf" {
-  ami_name        = "${local.ami_name_al2inf}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
-  instance_type   = "inf1.xlarge"
+  ami_name            = "${local.ami_name_al2inf}"
+  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  spot_instance_types = var.inf_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
@@ -20,7 +21,8 @@ source "amazon-ebs" "al2inf" {
     owners      = ["amazon"]
     most_recent = true
   }
-  ssh_username = "ec2-user"
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2kernel5dot10.pkr.hcl
+++ b/al2kernel5dot10.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al2kernel5dot10" {
-  ami_name        = "${local.ami_name_al2kernel5dot10}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 x86_64 ECS HVM GP2"
-  instance_type   = "c5.large"
+  ami_name            = "${local.ami_name_al2kernel5dot10}"
+  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 x86_64 ECS HVM GP2"
+  spot_instance_types = var.general_purpose_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
@@ -20,7 +21,8 @@ source "amazon-ebs" "al2kernel5dot10" {
     owners      = ["amazon"]
     most_recent = true
   }
-  ssh_username = "ec2-user"
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/al2kernel5dot10arm.pkr.hcl
+++ b/al2kernel5dot10arm.pkr.hcl
@@ -3,9 +3,10 @@ locals {
 }
 
 source "amazon-ebs" "al2kernel5dot10arm" {
-  ami_name        = "${local.ami_name_al2kernel5dot10arm}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 arm64 ECS HVM GP2"
-  instance_type   = "m6g.xlarge"
+  ami_name            = "${local.ami_name_al2kernel5dot10arm}"
+  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 arm64 ECS HVM GP2"
+  spot_instance_types = var.arm_instance_types
+  spot_price          = "auto"
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true
@@ -20,7 +21,8 @@ source "amazon-ebs" "al2kernel5dot10arm" {
     owners      = ["amazon"]
     most_recent = true
   }
-  ssh_username = "ec2-user"
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
   tags = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -170,3 +170,33 @@ variable "ecs_init_local_override" {
   description = "Specify a local init rpm under /additional-packages to be used for building AL2 and AL2022 AMIs. If empty it will use ecs_init_url if specified, otherwise the standard path"
   default     = ""
 }
+
+variable "general_purpose_instance_types" {
+  type        = list(string)
+  description = "List of available in-region instance types for general-purpose platform"
+  default     = ["c5.large"]
+}
+
+variable "gpu_instance_types" {
+  type        = list(string)
+  description = "List of available in-region instance types for GPU platform"
+  default     = ["c5.4xlarge"]
+}
+
+variable "arm_instance_types" {
+  type        = list(string)
+  description = "List of available in-region instance types for ARM platform"
+  default     = ["m6g.xlarge"]
+}
+
+variable "inf_instance_types" {
+  type        = list(string)
+  description = "List of available in-region instance types for INF platform"
+  default     = ["inf1.xlarge"]
+}
+
+variable "neu_instance_types" {
+  type        = list(string)
+  description = "List of available in-region instance types for NEU platform"
+  default     = ["trn1.2xlarge"]
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Currently we hard-code instance type to use for building AMIs. This PR makes use of `spot_instance_types` for building AMIs to allow multiple candidate instance types. The value is read from variable which means we will be able to dynamically configure the instance type(s) to be used. 

### Implementation details
<!-- How are the changes implemented? -->
* Create 5 new variables `[general_purpose|gpu|arm|inf|neu]_instance_types`, representing the 5 AMI platform/categories that we currently support. Each variable has a default value, which contains the instance type that we have been using so far.
* Updated all recipes. We replace `instance_type` with `spot_instance_types`. Each recipe's `spot_instance_types` reference their corresponding `<platform>_instance_types` variable. We use `spot_price = "auto"` in order to not set price limits. 
  * We are using `ssh_interface = "public_ip"` as a workaround for https://github.com/hashicorp/packer/issues/10347#issuecomment-740694599. https://github.com/hashicorp/packer-plugin-amazon/pull/308#pullrequestreview-1248685444 created by @sparrc should fix the issue once released.
* Some indentation changes due to formatting. 



### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no 

Tested AMI builds for al2, al2arm, al2gpu, al2inf, and al2022neu in us-west-2

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Use spot_instance_types for building AMIs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
