### PR TITLE
do not use spot instances to build AMIs

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al1" {
-  ami_name            = "${local.ami_name_al1}"
-  ami_description     = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version} x86_64 ECS HVM GP2"
-  spot_instance_types = var.general_purpose_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al1}"
+  ami_description = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version} x86_64 ECS HVM GP2"
+  instance_type   = var.general_purpose_instance_types[0]
   launch_block_device_mappings {
     volume_size           = 8
     delete_on_termination = true

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al2" {
-  ami_name            = "${local.ami_name_al2}"
-  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
-  spot_instance_types = var.general_purpose_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al2}"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  instance_type   = var.general_purpose_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2022.pkr.hcl
+++ b/al2022.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al2022" {
-  ami_name            = "${local.ami_name_al2022}"
-  ami_description     = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM EBS"
-  spot_instance_types = var.general_purpose_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al2022}"
+  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM EBS"
+  instance_type   = var.general_purpose_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2022arm.pkr.hcl
+++ b/al2022arm.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al2022arm" {
-  ami_name            = "${local.ami_name_al2022arm}"
-  ami_description     = "Amazon Linux AMI 2022.0.${var.ami_version} arm64 ECS HVM EBS"
-  spot_instance_types = var.arm_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al2022arm}"
+  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} arm64 ECS HVM EBS"
+  instance_type   = var.arm_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2022neu.pkr.hcl
+++ b/al2022neu.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al2022neu" {
-  ami_name            = "${local.ami_name_al2022neu}"
-  ami_description     = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM EBS"
-  spot_instance_types = var.neu_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al2022neu}"
+  ami_description = "Amazon Linux AMI 2022.0.${var.ami_version} x86_64 ECS HVM EBS"
+  instance_type   = var.neu_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al2arm" {
-  ami_name            = "${local.ami_name_al2arm}"
-  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} arm64 ECS HVM GP2"
-  spot_instance_types = var.arm_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al2arm}"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} arm64 ECS HVM GP2"
+  instance_type   = var.arm_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al2gpu" {
-  ami_name            = "${local.ami_name_al2gpu}"
-  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
-  spot_instance_types = var.gpu_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al2gpu}"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  instance_type   = var.gpu_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al2inf" {
-  ami_name            = "${local.ami_name_al2inf}"
-  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
-  spot_instance_types = var.inf_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al2inf}"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  instance_type   = var.inf_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10.pkr.hcl
+++ b/al2kernel5dot10.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al2kernel5dot10" {
-  ami_name            = "${local.ami_name_al2kernel5dot10}"
-  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 x86_64 ECS HVM GP2"
-  spot_instance_types = var.general_purpose_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al2kernel5dot10}"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 x86_64 ECS HVM GP2"
+  instance_type   = var.general_purpose_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10arm.pkr.hcl
+++ b/al2kernel5dot10arm.pkr.hcl
@@ -3,10 +3,9 @@ locals {
 }
 
 source "amazon-ebs" "al2kernel5dot10arm" {
-  ami_name            = "${local.ami_name_al2kernel5dot10arm}"
-  ami_description     = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 arm64 ECS HVM GP2"
-  spot_instance_types = var.arm_instance_types
-  spot_price          = "auto"
+  ami_name        = "${local.ami_name_al2kernel5dot10arm}"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 arm64 ECS HVM GP2"
+  instance_type   = var.arm_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
In PR #104, we added support for using spot instances to build AMIs. 
Since spot instance types are not supported in all regions where we build AMIs, we'll just use regular EC2 instances until support is available.

Note that we'd still continue to dynamically retrieve candidate instance types during build time.

### Implementation details
<!-- How are the changes implemented? -->
1. `spot_instance_types` -> `instance_type` and removed `spot_price` from all packer recipes.
2. The {family}_instance types variable is a list which we override during build time, by querying available instance types in that particular region. Since this list is already random or in no particular order, we'll use the first element in the list. This also works in case we want to use the default type.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

Tested the changes by building an AMI in eu-central-2.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Use non-spot instances to build AMIs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
