### PR TITLE
switched neuron ami instance type back to inf1

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -198,5 +198,5 @@ variable "inf_instance_types" {
 variable "neu_instance_types" {
   type        = list(string)
   description = "List of available in-region instance types for NEU platform"
-  default     = ["trn1.2xlarge"]
+  default     = ["inf1.xlarge"]
 }


### PR DESCRIPTION
### Summary
Fixes AL2023 Neuron instance type to inf1 because trn1 is not available everywhere

### Implementation details
- changed the default for neu builds
- we used to build al2022 neu builds with inf1 but this is a remnant of a change that would pick trn1 if it was available in the region

### Description for the changelog
Fix - default AL2023 neuron builds to inf1 instance types

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
