### PR TITLE
Handle dnf cleanup for AL2023 AMIs

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
+# Below command actually runs `sudo dnf clean all` for AL2023.
+# See https://docs.aws.amazon.com/linux/al2023/ug/package-management.html for more details.
 sudo yum clean all
 
 function cleanup() {
@@ -167,9 +169,11 @@ fi
 # delete a few items missed in https://docs.aws.amazon.com/imagebuilder/latest/userguide/security-best-practices.html
 sudo rm -rf \
     /etc/machine-id \
+    /var/cache/dnf \
     /var/cache/yum \
     /tmp/* \
     /var/lib/dhcp/dhclient.* \
+    /var/lib/dnf/history* \
     /var/lib/yum/history \
     /var/log/secure \
     /var/log/wtmp \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
As [stated in the Amazon Linux 2023 User Guide](https://docs.aws.amazon.com/linux/al2023/ug/package-management.html):

> In Amazon Linux 2023 (AL2023), the default software package management tool is DNF. DNF is the successor to YUM, the package management tool in Amazon Linux 2.

> In AL2023 the `yum` command is still available, but as a pointer to the `dnf` command. 

There is a bug where our cleanup script is missing steps in cleaning up DNF files, including DNF history (see example in Testing section below). This pull request updates our cleanup script to handle cleanup of DNF files.

### Implementation details
<!-- How are the changes implemented? -->
Update cleanup script with commands to clean up DNF files in the same way we do for YUM files.
Also add comment for context regarding YUM commands being redirected to DNF for AL2023.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
**Before this pull request's changes** (i.e., on fresh instance using latest ECS-Optimized AL2023 AMI):

We can see below that there is lingering package management history, which is inconsistent with our other non-AL2023 AMIs and Amazon Linux base AMIs.

```
$ sudo dnf history
ID     | Command line                                         | Date and time    | Action(s)      | Altered
-----------------------------------------------------------------------------------------------------------
     4 | install -y ecs-service-connect-agent                 | 2023-05-25 23:10 | Install        |    1   
     3 | install -y /tmp/tmp.COhnDaYHko/ecs-init.rpm          | 2023-05-25 23:09 | Install        |    1   
     2 | install -y docker-20.10.17 containerd-1.6.8          | 2023-05-25 23:09 | Install        |   13 EE
     1 | install -y amazon-efs-utils amazon-ssm-agent amazon- | 2023-05-25 23:09 | Install        |   20 EE
```

**After this pull request's changes** (i.e., on fresh instance using custom built ECS-Optimized AL2023 AMI with the changes in this pull request):

We can see below that there is no lingering package management history, which is consistent with our other non-AL2023 AMIs and Amazon Linux base AMIs.

```
$ sudo dnf history
ID     | Command line                                            | Date and time    | Action(s)      | Altered
--------------------------------------------------------------------------------------------------------------
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Handle dnf cleanup for AL2023 AMIs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
