### PR TITLE
Add a script to generate release notes

### DIFF
--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+
+set -eo pipefail
+
+usage() {
+    echo "Usage:"
+    echo "  $0 AL2_GPU_NVIDIA_VERSION AL2_GPU_CUDA_VERSION AL1_CONTAINERD_VERSION"
+    echo "Example:"
+    echo "  $0 470.182.03 11.4 1.4.13"
+}
+
+# Parameters
+al2_gpu_nvidia_version=$1
+al2_gpu_cuda_version=$2
+al1_containerd_version=$3
+
+if [ "$al2_gpu_nvidia_version" == "" ]; then
+    echo "Error: AL2 GPU NVIDIA version is empty"
+    usage
+    exit 1
+fi
+if [ "$al2_gpu_cuda_version" == "" ]; then
+    echo "Error: AL2 GPU CUDA version is empty"
+    usage
+    exit 1
+fi
+if [ "$al1_containerd_version" == "" ]; then
+    echo "Error: AL1 containerd version is empty"
+    usage
+    exit 1
+fi
+
+# Read some information from pkrvars file
+ami_version=""
+containerd_version_al2023=""
+distribution_release_al2023=""
+containerd_version=""
+readonly pkrvars="release.auto.pkrvars.hcl"
+while IFS='=' read -r key value; do
+    # Remove leading and trailing whitespace, and quotes from the key and value
+    key=$(echo "$key" | awk '{$1=$1};1')
+    value=$(echo "$value" | awk '{$1=$1};1')
+    value=${value//\"/} # strip quotes
+
+    if [ "$key" == "ami_version" ]; then
+        ami_version=$value
+    fi
+    if [ "$key" == "containerd_version_al2023" ]; then
+        containerd_version_al2023=$value
+    fi
+    if [ "$key" == "distribution_release_al2023" ]; then
+        distribution_release_al2023=$value
+    fi
+    if [ "$key" == "containerd_version" ]; then
+        containerd_version=$value
+    fi
+done <$pkrvars
+
+if [ "$ami_version" == "" ]; then
+    echo "Error: AMI version was not found in $pkrvars"
+    exit 1
+fi
+if [ "$containerd_version_al2023" == "" ]; then
+    echo "Error: Containerd version was not found for AL2023 in $pkrvars"
+    exit 1
+fi
+if [ "$distribution_release_al2023" == "" ]; then
+    echo "Error: Distribution release version was not found for AL2023 in $pkrvars"
+    exit 1
+fi
+if [ "$containerd_version" == "" ]; then
+    echo "Error: Containerd version was not found in $pkrvars"
+    exit 1
+fi
+
+# Gets ECS Optimized AMI details from SSM parameter store given the paramter name.
+# Uses the default AWS credentials as the parameter is public and can be
+# fetched from a standard region (us-west-2 is used).
+get_ami_details() {
+    parameter_name=$1
+    ami_details=$(aws ssm --region "us-west-2" get-parameters --names $parameter_name --query 'Parameters[0].Value' --output text | jq .)
+    ami_name=$(echo $ami_details | jq -r '.image_name')
+    agent_version=$(echo $ami_details | jq -r '.ecs_agent_version')
+    docker_version=$(echo $ami_details | jq -r '.ecs_runtime_version' | awk '{print $3}')
+    source_ami_name=$(echo $ami_details | jq -r '.source_image_name')
+    echo "$ami_name $agent_version $docker_version $source_ami_name"
+}
+
+# AL2023 AMI details
+read ami_name_al2023_x86 agent_version_al2023_x86 docker_version_al2023_x86 source_ami_name_al2023_x86 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended")
+read ami_name_al2023_arm agent_version_al2023_arm docker_version_al2023_arm source_ami_name_al2023_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended")
+read ami_name_al2023_neuron agent_version_al2023_neuron docker_version_al2023_neuron source_ami_name_al2023_neuron <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2023/neuron/recommended")
+
+# AL2 AMI details
+read ami_name_al2_x86 agent_version_al2_x86 docker_version_al2_x86 source_ami_name_al2_x86 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended")
+read ami_name_al2_arm agent_version_al2_arm docker_version_al2_arm source_ami_name_al2_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended")
+read ami_name_al2_gpu agent_version_al2_gpu docker_version_al2_gpu source_ami_name_al2_gpu <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended")
+read ami_name_al2_inf agent_version_al2_inf docker_version_al2_inf source_ami_name_al2_inf <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/inf/recommended")
+read ami_name_al2_kernel_5_10 agent_version_al2_kernel_5_10 docker_version_al2_kernel_5_10 source_ami_name_al2_kernel_5_10 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/kernel-5.10/recommended")
+read ami_name_al2_kernel_5_10_arm agent_version_al2_kernel_5_10_arm docker_version_al2_kernel_5_10_arm source_ami_name_al2_kernel_5_10_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/kernel-5.10/arm64/recommended")
+
+# AL1 AMI details
+read ami_name_al1 agent_version_al1 docker_version_al1 source_ami_name_al1 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux/recommended")
+
+# Prepare release notes
+release_notes="### Source AMI release notes
+---
+* [Amazon Linux 2023 release notes](https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html)
+* [Amazon Linux 2 release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)
+* [Amazon Linux release notes](https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes)
+
+### Changelog
+---
+https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#$ami_version
+
+### Amazon ECS-optimized Amazon Linux 2023 AMI
+---
+#### AMD64
+- AMI name: $ami_name_al2023_x86
+- ECS Agent version: [$agent_version_al2023_x86](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2023_x86)
+- Docker version: $docker_version_al2023_x86
+- Containerd version: $containerd_version_al2023
+- Source AMI name: $source_ami_name_al2023_x86
+- Distribution al2023 release: $distribution_release_al2023
+
+#### ARM64
+- AMI name: $ami_name_al2023_arm
+- ECS Agent version: [$agent_version_al2023_arm](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2023_arm)
+- Docker version: $docker_version_al2023_arm
+- Containerd version: $containerd_version_al2023
+- Source AMI name: $source_ami_name_al2023_arm
+- Distribution al2023 release: $distribution_release_al2023
+
+#### Neuron
+- AMI name: $ami_name_al2023_neuron
+- ECS Agent version: [$agent_version_al2023_neuron](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2023_neuron)
+- Docker version: $docker_version_al2023_neuron
+- Containerd version: $containerd_version_al2023
+- Source AMI name: $source_ami_name_al2023_neuron
+- Distribution al2023 release: $distribution_release_al2023
+
+### Amazon ECS-optimized Amazon Linux 2 AMI
+---
+#### AMD64 (Kernel 4.14)
+- AMI name: $ami_name_al2_x86
+- ECS Agent version: [$agent_version_al2_x86](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_x86)
+- Docker version: $docker_version_al2_x86
+- Containerd version: $containerd_version
+- Source AMI name: $source_ami_name_al2_x86
+
+#### ARM64 (Kernel 4.14)
+- AMI name: $ami_name_al2_arm
+- ECS Agent version: [$agent_version_al2_arm](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_arm)
+- Docker version: $docker_version_al2_arm
+- Containerd version: $containerd_version
+- Source AMI name: $source_ami_name_al2_arm
+
+#### Neuron (Kernel 4.14)
+- AMI name: $ami_name_al2_inf
+- ECS Agent version: [$agent_version_al2_inf](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_inf)
+- Docker version: $docker_version_al2_inf
+- Containerd version: $containerd_version
+- Source AMI name: $source_ami_name_al2_inf
+
+#### GPU (Kernel 4.14)
+- AMI name: $ami_name_al2_gpu
+- ECS Agent version: [$agent_version_al2_gpu](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_gpu)
+- Docker version: $docker_version_al2_gpu
+- Containerd version: $containerd_version
+- NVIDIA driver version: $al2_gpu_nvidia_version
+- CUDA version: $al2_gpu_cuda_version
+- Source AMI name: $source_ami_name_al2_gpu
+
+#### AMD64 (Kernel 5.10)
+- AMI name: $ami_name_al2_kernel_5_10
+- ECS Agent version: [$agent_version_al2_kernel_5_10](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_kernel_5_10)
+- Docker version: $docker_version_al2_kernel_5_10
+- Containerd version: $containerd_version
+- Source AMI name: $source_ami_name_al2_kernel_5_10
+
+#### ARM64 (Kernel 5.10)
+- AMI name: $ami_name_al2_kernel_5_10_arm
+- ECS Agent version: [$agent_version_al2_kernel_5_10_arm](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_kernel_5_10_arm)
+- Docker version: $docker_version_al2_kernel_5_10_arm
+- Containerd version: $containerd_version
+- Source AMI name: $source_ami_name_al2_kernel_5_10_arm
+
+### Amazon ECS-optimized Amazon Linux AMI
+---
+The Amazon ECS-optimized Amazon Linux AMI is deprecated as of April 15, 2021. After that date, Amazon ECS will continue providing critical and important security updates for the AMI but will not add support for new features.
+
+- AMI name: $ami_name_al1
+- ECS Agent version: [$agent_version_al1](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al1)
+- Docker version: $docker_version_al1
+- Containerd version: $al1_containerd_version
+- Source AMI name: $source_ami_name_al1"
+
+echo "$release_notes"

--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -79,10 +79,10 @@ fi
 get_ami_details() {
     parameter_name=$1
     ami_details=$(aws ssm --region "us-west-2" get-parameters --names $parameter_name --query 'Parameters[0].Value' --output text | jq .)
-    ami_name=$(echo $ami_details | jq -r '.image_name')
-    agent_version=$(echo $ami_details | jq -r '.ecs_agent_version')
-    docker_version=$(echo $ami_details | jq -r '.ecs_runtime_version' | awk '{print $3}')
-    source_ami_name=$(echo $ami_details | jq -r '.source_image_name')
+    ami_name=$(echo "$ami_details" | jq -r '.image_name')
+    agent_version=$(echo "$ami_details" | jq -r '.ecs_agent_version')
+    docker_version=$(echo "$ami_details" | jq -r '.ecs_runtime_version' | awk '{print $3}')
+    source_ami_name=$(echo "$ami_details" | jq -r '.source_image_name')
     echo "$ami_name $agent_version $docker_version $source_ami_name"
 }
 

--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -28,44 +28,25 @@ if [ "$al2_gpu_cuda_version" == "" ]; then
 fi
 
 # Read some information from pkrvars file
-ami_version=""
-containerd_version_al2023=""
-distribution_release_al2023=""
-containerd_version=""
 readonly pkrvars="release.auto.pkrvars.hcl"
-while IFS='=' read -r key value; do
-    # Remove leading and trailing whitespace, and quotes from the key and value
-    key=$(echo "$key" | awk '{$1=$1};1')
-    value=$(echo "$value" | awk '{$1=$1};1')
-    value=${value//\"/} # strip quotes
+readonly ami_version=$(cat $pkrvars | grep -w 'ami_version' | cut -d "\"" -f2)
+readonly containerd_version_al2023=$(cat $pkrvars | grep -w 'containerd_version_al2023' | cut -d "\"" -f2)
+readonly distribution_release_al2023=$(cat $pkrvars | grep -w 'distribution_release_al2023' | cut -d "\"" -f2)
+readonly containerd_version=$(cat $pkrvars | grep -w 'containerd_version' | cut -d "\"" -f2)
 
-    if [ "$key" == "ami_version" ]; then
-        ami_version=$value
-    fi
-    if [ "$key" == "containerd_version_al2023" ]; then
-        containerd_version_al2023=$value
-    fi
-    if [ "$key" == "distribution_release_al2023" ]; then
-        distribution_release_al2023=$value
-    fi
-    if [ "$key" == "containerd_version" ]; then
-        containerd_version=$value
-    fi
-done <$pkrvars
-
-if [ "$ami_version" == "" ]; then
+if [ -z "$ami_version" ]; then
     echo "Error: AMI version was not found in $pkrvars"
     exit 1
 fi
-if [ "$containerd_version_al2023" == "" ]; then
+if [ -z "$containerd_version_al2023" ]; then
     echo "Error: Containerd version was not found for AL2023 in $pkrvars"
     exit 1
 fi
-if [ "$distribution_release_al2023" == "" ]; then
+if [ -z "$distribution_release_al2023" ]; then
     echo "Error: Distribution release version was not found for AL2023 in $pkrvars"
     exit 1
 fi
-if [ "$containerd_version" == "" ]; then
+if [ -z "$containerd_version" ]; then
     echo "Error: Containerd version was not found in $pkrvars"
     exit 1
 fi

--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -29,10 +29,10 @@ fi
 
 # Read some information from pkrvars file
 readonly pkrvars="release.auto.pkrvars.hcl"
-readonly ami_version=$(cat $pkrvars | grep -w 'ami_version' | cut -d "\"" -f2)
-readonly containerd_version_al2023=$(cat $pkrvars | grep -w 'containerd_version_al2023' | cut -d "\"" -f2)
-readonly distribution_release_al2023=$(cat $pkrvars | grep -w 'distribution_release_al2023' | cut -d "\"" -f2)
-readonly containerd_version=$(cat $pkrvars | grep -w 'containerd_version' | cut -d "\"" -f2)
+readonly ami_version=$(cat $pkrvars | grep -w 'ami_version' | cut -d '"' -f2)
+readonly containerd_version_al2023=$(cat $pkrvars | grep -w 'containerd_version_al2023' | cut -d '"' -f2)
+readonly distribution_release_al2023=$(cat $pkrvars | grep -w 'distribution_release_al2023' | cut -d '"' -f2)
+readonly containerd_version=$(cat $pkrvars | grep -w 'containerd_version' | cut -d '"' -f2)
 
 if [ -z "$ami_version" ]; then
     echo "Error: AMI version was not found in $pkrvars"

--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -4,9 +4,11 @@ set -eo pipefail
 
 usage() {
     echo "Usage:"
-    echo "  $0 AL2_GPU_NVIDIA_VERSION AL2_GPU_CUDA_VERSION AL1_CONTAINERD_VERSION"
+    echo "  $0 AL2_GPU_NVIDIA_VERSION AL2_GPU_CUDA_VERSION [AL1_CONTAINERD_VERSION]"
+    echo "  AL1_CONTAINERD_VERSION should not be provided if there is no AL1 AMI release"
     echo "Example:"
-    echo "  $0 470.182.03 11.4 1.4.13"
+    echo "  $0 470.182.03 11.4 1.4.13 # AL1 release included"
+    echo "  $0 470.182.03 11.4        # No AL1 release"
 }
 
 # Parameters
@@ -21,11 +23,6 @@ if [ "$al2_gpu_nvidia_version" == "" ]; then
 fi
 if [ "$al2_gpu_cuda_version" == "" ]; then
     echo "Error: AL2 GPU CUDA version is empty"
-    usage
-    exit 1
-fi
-if [ "$al1_containerd_version" == "" ]; then
-    echo "Error: AL1 containerd version is empty"
     usage
     exit 1
 fi
@@ -183,7 +180,11 @@ https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#$ami_version
 - ECS Agent version: [$agent_version_al2_kernel_5_10_arm](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_kernel_5_10_arm)
 - Docker version: $docker_version_al2_kernel_5_10_arm
 - Containerd version: $containerd_version
-- Source AMI name: $source_ami_name_al2_kernel_5_10_arm
+- Source AMI name: $source_ami_name_al2_kernel_5_10_arm"
+
+# Include AL1 release notes if there was an AL1 release
+if [ -n "$al1_containerd_version" ]; then
+    al1_release_notes="
 
 ### Amazon ECS-optimized Amazon Linux AMI
 ---
@@ -194,5 +195,8 @@ The Amazon ECS-optimized Amazon Linux AMI is deprecated as of April 15, 2021. Af
 - Docker version: $docker_version_al1
 - Containerd version: $al1_containerd_version
 - Source AMI name: $source_ami_name_al1"
+
+    release_notes="${release_notes}${al1_release_notes}"
+fi
 
 echo "$release_notes"

--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -14,7 +14,7 @@ usage() {
 # Parameters
 al2_gpu_nvidia_version=$1
 al2_gpu_cuda_version=$2
-al1_containerd_version=$3
+al1_containerd_version=$3 # Optional, will include AL1 in the release notes if provided
 
 if [ "$al2_gpu_nvidia_version" == "" ]; then
     echo "Error: AL2 GPU NVIDIA version is empty"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add a script `generate-release-notes.sh` for generating release notes. 

The script takes two required parameters - AL2 GPU NVIDIA driver version and AL2 GPU CUDA driver version, and one optional parameter - AL1 containerd version. AL1 containerd version should only be provided when there is an AL1 release. The script will include AL1 in the generated release notes if AL1 containerd version is provided.

```
Usage:
  ./generate-release-notes.sh AL2_GPU_NVIDIA_VERSION AL2_GPU_CUDA_VERSION [AL1_CONTAINERD_VERSION]
  AL1_CONTAINERD_VERSION should not be provided if there is no AL1 AMI release
Example:
  ./generate-release-notes.sh 470.182.03 11.4 1.4.13 # AL1 release included
  ./generate-release-notes.sh 470.182.03 11.4        # No AL1 release
```

### Implementation details
<!-- How are the changes implemented? -->
The script - 
* requires AL2 GPU NVIDIA driver version and AL2 GPU CUDA driver version to be provided as command-line arguments,
* expects AL1 containerd version to be provided as a command-line argument if AL1 is to be included in the release notes,
* reads the new AMI version, AL2023 containerd version, AL2023 distribution release, and containerd version from `release.auto.pkrvars.hcl` file,
* gets AMI name, ECS Agent version, Docker version, and source AMI name for each platform and architecture by querying SSM parameter store for the corresponding latest ECS Optimized AMI, and
* generates the release notes from all the collected information.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Generated release notes for `20230606` release using `./generate-release-notes.sh 470.182.03 11.4 1.4.13` command and compared the generated release notes against [the expected release notes](https://github.com/aws/amazon-ecs-ami/releases/tag/20230606) using `diff`. No differences were found.

Generated release notes excluding AL1 using `./generate-release-notes.sh 470.182.03 11.4` command and confirmed that AL1 is not included in the generated output. 

Manually tested incorrect usage.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add a script to generate release notes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
