### PR TITLE
update exec ssm version

### DIFF
--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -20,12 +20,12 @@ mkdir -p /tmp/ssm-binaries && cd /tmp/ssm-binaries
 case $ARCHITECTURE in
 'x86_64')
     curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
-    echo "0100e5f6299274150d9252eb56ace6f3ff797ee2e9c17be1d6b9b8035b75315c ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
+    echo "94be5ddec82d67d2f799d2fd1c8ab3f597e5d166b9750891a135d3093e15aa24 ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
     sha256sum -c ./amazon-ssm-agent.tar.gz.sha256
     ;;
 'aarch64')
     curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
-    echo "2f345a98ed25a9ffeb12355533b242110a502c929dd3abd61c2936000d22f230 ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
+    echo "f306be07eb4d82ef367af71de87a0aeb05097282731f361dbe782e29d3dcf660 ./amazon-ssm-agent.tar.gz" >./amazon-ssm-agent.tar.gz.sha256
     sha256sum -c ./amazon-ssm-agent.tar.gz.sha256
     ;;
 esac

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -73,7 +73,7 @@ variable "containerd_version_al2023" {
 
 variable "exec_ssm_version" {
   type        = string
-  default     = "3.1.1732.0"
+  default     = "3.2.1478.0"
   description = "SSM binary version to build ECS exec support with."
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- Update the execute-command-agent ssm static binary to version `3.2.1478.0`
- Update the shasum for each.

### Implementation details
Validated previous `3.1.1732.0` shasums using the `sha256sum` linux utility.  Downloaded each of the new tar files and generated the shas using the same utility.

### Testing
Validated the generated shas for both the previous and the current versions multiple times for each arch.

New tests cover the changes: no

### Description for the changelog
Update execute-command-agent to 3.2.1478.0.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
