### PR TITLE
Enable NVIDIA Persistence Daemon by default

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support.sh
+++ b/scripts/enable-ecs-agent-gpu-support.sh
@@ -43,9 +43,12 @@ sudo yum install -y kernel-devel-$(uname -r) \
 sudo yum install -y cuda-drivers \
     cuda
 
-# The Fabric Manager service needs be started and enabled on EC2 P4d instances
+# The Fabric Manager service needs to be started and enabled on EC2 P4d instances
 # in order to configure NVLinks and NVSwitches
 sudo systemctl enable nvidia-fabricmanager
+# NVIDIA Persistence Daemon needs to be started and enabled on P5 instances
+# to maintain persistent software state in the NVIDIA driver.
+sudo systemctl enable nvidia-persistenced
 mkdir -p /tmp/ecs
 echo 'ECS_ENABLE_GPU_SUPPORT=true' >>/tmp/ecs/ecs.config
 sudo mv /tmp/ecs/ecs.config /var/lib/ecs/ecs.config


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is to enable NVIDIA Persistence Daemon by default

### Implementation details 
<!-- How are the changes implemented? -->
Added `sudo systemctl enable nvidia-persistenced` to `scripts/enable-ecs-agent-gpu-support.sh`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
- REGION=us-west-2 make al2gpu
- Launch instance with test AMI and verify nvidia-persistenced.service is enabled, active (running)
```
systemctl status nvidia-persistenced
● nvidia-persistenced.service - NVIDIA Persistence Daemon
   Loaded: loaded (/usr/lib/systemd/system/nvidia-persistenced.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2023-09-26 04:07:02 UTC; 1min 7s ago
 Main PID: 4705 (nvidia-persiste)
    Tasks: 1
   Memory: 28.1M
   CGroup: /system.slice/nvidia-persistenced.service
           └─4705 /usr/bin/nvidia-persistenced --verbose
```
- Run functional set suite against the AMIs created and verify exec tests succeed

New tests cover the changes: <!-- yes|no -->  No new tests added

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enable NVIDIA Persistence Daemon by default

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
