### PR TITLE
Update SSM Agent version to 3.2.1630.0 for ECS exec

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -73,7 +73,7 @@ variable "containerd_version_al2023" {
 
 variable "exec_ssm_version" {
   type        = string
-  default     = "3.2.1478.0"
+  default     = "3.2.1630.0"
   description = "SSM binary version to build ECS exec support with."
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Upgrade Amazon SSM Agent version to[ 3.2.1630.0](https://github.com/aws/amazon-ssm-agent/releases/tag/3.2.1630.0), which is the latest stable version, to address CVE listed as follows.

1. [Important] https://alas.aws.amazon.com/ALAS-2023-1825.html
2. [Important] https://alas.aws.amazon.com/AL2/ALAS-2023-2238.html
3. [Important] https://alas.aws.amazon.com/AL2023/ALAS-2023-373.html
4. [Important] https://alas.aws.amazon.com/AL2023/ALAS-2023-339.html

### Implementation details
Update `exec_ssm_version` in variables.pkr.hcl.

### Testing
1. Built Alpha ECS optimized AL2, AL2 ARM, AL2023, AL2023 ARM, and AL1 AMIs with following parameters for testing
```
ami_version          = "29999999"
ecs_agent_version    = "1.76.0"
ecs_init_rev         = "1"
docker_version       = "20.10.23"
docker_version_al2023 = "20.10.23"
containerd_version   = "1.6.19"
containerd_version_al2023 = "1.6.19"
source_ami_al1       = "amzn-ami-minimal-hvm-2018.03.0.20230918.0-x86_64-ebs"
source_ami_al2       = "amzn2-ami-minimal-hvm-2.0.20230926.0-x86_64-ebs"
source_ami_al2arm    = "amzn2-ami-minimal-hvm-2.0.20230926.0-arm64-ebs"
source_ami_al2023    = "al2023-ami-minimal-2023.2.20230920.1-kernel-6.1-x86_64"
source_ami_al2023arm = "al2023-ami-minimal-2023.2.20230920.1-kernel-6.1-arm64"
kernel_version_al2023    = "-kernel-6.1"
kernel_version_al2023arm = "-kernel-6.1"
distribution_release_al2023  = "2023.2.20230920"
```
5. Ran e2e functional tests on these Alpha ECS optimized AMIs, and confirmed SSM Agent and ECS Exec tests passed.

New tests cover the changes: no

### Description for the changelog
Update SSM Agent version to 3.2.1630.0 for ECS exec


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
