### PR TITLE
add al2keplergpu build recipe to build gpu amis for kepler arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ al2arm: check-region init validate release.auto.pkrvars.hcl
 al2gpu: check-region init validate release.auto.pkrvars.hcl
 	./packer build -only="amazon-ebs.al2gpu" -var "region=${REGION}" .
 
+.PHONY: al2keplergpu
+al2keplergpu: check-region init validate release.auto.pkrvars.hcl
+	./packer build -only="amazon-ebs.al2keplergpu" -var "region=${REGION}" .
+
 .PHONY: al2inf
 al2inf: check-region init validate release.auto.pkrvars.hcl
 	./packer build -only="amazon-ebs.al2inf" -var "region=${REGION}" .

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ It will create a private AMI in whatever account you are running it in.
 ## Instructions
 
 1. Setup AWS cli credentials.
-2. Make the recipe that you want, REGION must be specified. Options are: al1, al2, al2arm, al2gpu, al2inf, 
+2. Make the recipe that you want, REGION must be specified. Options are: al1, al2, al2arm, al2gpu, al2keplergpu, al2inf, 
 al2kernel5dot10, al2kernel5dot10arm, al2023, al2023arm, al2023neu.
 ```
 REGION=us-west-2 make al2
 ```
+
+**NOTE**: `al2keplergpu` is a build recipe that this package supports to build ECS-Optimized GPU AMIs for instances with GPUs
+with Kepler architecture (such as P2 type instances). ECS-Optimized GPU AMIs for this target are not officially built and published.
 
 ## Configuration
 

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -37,6 +37,7 @@ build {
     "source.amazon-ebs.al2",
     "source.amazon-ebs.al2arm",
     "source.amazon-ebs.al2gpu",
+    "source.amazon-ebs.al2keplergpu",
     "source.amazon-ebs.al2inf",
     "source.amazon-ebs.al2kernel5dot10",
     "source.amazon-ebs.al2kernel5dot10arm"

--- a/al2keplergpu.pkr.hcl
+++ b/al2keplergpu.pkr.hcl
@@ -1,0 +1,33 @@
+locals {
+  ami_name_al2keplergpu = "${var.ami_name_prefix_al2}-kepler-gpu-hvm-2.0.${var.ami_version}-x86_64-ebs"
+}
+
+source "amazon-ebs" "al2keplergpu" {
+  ami_name        = "${local.ami_name_al2keplergpu}"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  instance_type   = var.gpu_instance_types[0]
+  launch_block_device_mappings {
+    volume_size           = var.block_device_size_gb
+    delete_on_termination = true
+    volume_type           = "gp2"
+    device_name           = "/dev/xvda"
+  }
+  region = var.region
+  source_ami_filter {
+    filters = {
+      name = "${var.source_ami_al2}"
+    }
+    owners      = ["amazon"]
+    most_recent = true
+  }
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
+  tags = {
+    os_version          = "Amazon Linux 2"
+    source_image_name   = "{{ .SourceAMIName }}"
+    ecs_runtime_version = "Docker version ${var.docker_version}"
+    ecs_agent_version   = "${var.ecs_agent_version}"
+    ami_type            = "al2keplergpu"
+    ami_version         = "2.0.${var.ami_version}"
+  }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
With the release of `20230912` AMI, default Nvidia and Cuda drivers were updated in AL repos. These further later added support for P5 instances but lost support for P2 instances (Kepler architecture), for which Nvidia 470 is the latest supported driver.

This PR adds a new `al2keplergpu` build recipe to support building AL2 ECS Optimized GPU AMIs with this package for instances with Kepler arch GPUs (such as P2 type). This recipe is NOT a new supported ECS platform, no new AMI types are published for this type. Rather it is a build recipe for anyone to build their own ECS AMIs for Kepler instances with GPUs on Kepler architecture.

This will enable customers to create their own GPU supported AMIs for Kepler based GPU instances (such as P2.xlarge) by
* Setting the required Agent and source AL2 versions in `release.auto.pkrvars.hcl` or `overrides.auto.pkrvars.hcl`
* Then running `REGION=<region> make al2keplergpu`

### Implementation details
<!-- How are the changes implemented? -->
* Adds new packer file for `al2keplergpu` and new makefile target
* Changes in `scripts/enable-ecs-agent-gpu-support.sh` to pin package versions to supported versions for Kepler type GPUs. Also, exclude `nvidia` and `cuda` packages in the built AMI from yum updates to keep Kepler support for the built ami while maintaining regular updates.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Make amis `REGION=us-west-2 make al2keplergpu` and `REGION=us-west-2 make al2gpu`
* Build `al2keplergpu` ami, run functional test suite on p2.xlarge instance, verify tests succeed.
* Verified Nvidia driver `470.182.03` and Cuda `11.4` is installed.
* Verified instance is registered with `ecs.capability.gpu-driver-version:470.182.03`
* Verified running `yum update -y` does not update Nvidia/Cuda drivers. `/etc/yum.conf` has the exclusion `exclude=*nvidia* *cuda*`
* Build `al2gpu` ami, run functional test suite on g4dn.xlarge instance, verify tests succeed.
* Verify Nvidia driver `535.54.03` and Cuda `12.2` is installed.
* Verified instance is registered with `ecs.capability.gpu-driver-version:535.54.03`

New tests cover the changes: <!-- yes|no -->
No new tests

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
add al2keplergpu build recipe to build gpu amis for kepler arch

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
