### PR TITLE
Temporarily override GPU base AMI

### DIFF
--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -15,7 +15,7 @@ source "amazon-ebs" "al2gpu" {
   region = var.region
   source_ami_filter {
     filters = {
-      name = "${var.source_ami_al2}"
+      name = "${var.source_ami_al2_gpu}"
     }
     owners      = ["amazon"]
     most_recent = true

--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -71,6 +71,7 @@ distribution_release_al2023=$(curl -s https://al2023-repos-us-west-2-de612dc2.s3
 
 readonly ami_name_al2_kernel5dot10arm ami_name_al2_kernel5dot10 ami_name_al2_arm ami_name_al2_x86 ami_name_al1 ami_name_al2023_arm ami_name_al2023_x86 distribution_release_al2023
 
+# Temporarily override base AMI for AL2 GPU due to a known al2 kernel and EFA/Nvidia incompatibility
 cat >|release.auto.pkrvars.hcl <<EOF
 ami_version          = "$ami_version"
 ecs_agent_version    = "$agent_version"
@@ -84,6 +85,7 @@ source_ami_al2       = "$ami_name_al2_x86"
 source_ami_al2arm    = "$ami_name_al2_arm"
 source_ami_al2kernel5dot10    = "$ami_name_al2_kernel5dot10"
 source_ami_al2kernel5dot10arm = "$ami_name_al2_kernel5dot10arm"
+source_ami_al2_gpu   = "amzn2-ami-minimal-hvm-2.0.20230926.0-x86_64-ebs"
 source_ami_al2023    = "$ami_name_al2023_x86"
 source_ami_al2023arm = "$ami_name_al2023_arm"
 kernel_version_al2023    = "$kernel_version_al2023_x86"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -87,6 +87,12 @@ variable "source_ami_al2arm" {
   description = "Amazon Linux 2 ARM source AMI to build from."
 }
 
+variable "source_ami_al2_gpu" {
+  type        = string
+  description = "Amazon Linux 2 source AMI to build AL2GPU AMI from. This is a temporary override."
+  default     = "amzn2-ami-minimal-hvm-2.0.20230926.0-x86_64-ebs"
+}
+
 variable "source_ami_al2kernel5dot10" {
   type        = string
   description = "Amazon Linux 2 Kernel 5.10 source AMI to build from."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Temporarily override base AMI for AL2 GPU due to a known al2 kernel and EFA/Nvidia incompatibility

### Implementation details
<!-- How are the changes implemented? -->
Add a variable and change al2gpu recipe to use a pinned al2 base AMI.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> N/A

Ran `REGION=us-west-2 make al2gpu` and verified a pinned base AMI is used (ami-0bac1825e471f5042)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
