### PR TITLE
Add post-kepler nvidia open kernel module installation steps

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -89,8 +89,7 @@ variable "source_ami_al2arm" {
 
 variable "source_ami_al2_gpu" {
   type        = string
-  description = "Amazon Linux 2 source AMI to build AL2GPU AMI from. This is a temporary override."
-  default     = "amzn2-ami-minimal-hvm-2.0.20230926.0-x86_64-ebs"
+  description = "Amazon Linux 2 source AMI to build AL2GPU AMI from."
 }
 
 variable "source_ami_al2kernel5dot10" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This change builds a .tar file of the open source NVIDIA kernel module in `/var/lib/dkms-archive/nvidia-open`.  It also adds a script to replace the closed source NVIDIA kernel module with this open source NVIDIA kernel module.  This allows AMI users (especially those using P4/P5 instances with EFA) to run a simple command in userdata/cloud-init to replace the kernel module.

This also un-pins the gpu kernel version to pull in the latest updates.

### Testing
Built AMI using packer `REGION=us-west-2 make al2gpu`.  
Resulting test AMI: ami-028c1796865c0d2ae
I started an instance of this ami with userdata to run the open module installation script:
```
#!/bin/bash
/var/lib/ecs/scripts/install-nvidia-open-kmod.sh
yum versionlock \
cuda-* \
cuda-drivers-* \
cuda-drivers-fabricmanager-* \
nvidia-container-toolkit-*
```
cloud-init output:
```
Cloud-init v. 19.3-46.amzn2.0.1 running 'modules:final' at Fri, 08 Dec 2023 19:27:06 +0000. Up 83.46 seconds.
+ DKMS=/usr/sbin/dkms
+ DKMS_ARCHIVE_DIR=/var/lib/dkms-archive
++ uname -r
+ KERNEL_VERSION=4.14.322-246.539.amzn2.x86_64
++ /usr/sbin/dkms status -m nvidia
++ awk '{print $2}'
++ tr -d ,:
+ MODULE_VERSION=535.129.03
+ /usr/sbin/dkms uninstall -m nvidia -v 535.129.03

-------- Uninstall Beginning --------
Module:  nvidia
Version: 535.129.03
Kernel:  4.14.322-246.539.amzn2.x86_64 (x86_64)
-------------------------------------
...
------------------------------
Deleting module version: 535.129.03
completely from the DKMS tree.
------------------------------
Done.
+ echo 'found nvidia kernel module: 535.129.03'
found nvidia kernel module: 535.129.03
+ MODULE_ARCHIVE=/var/lib/dkms-archive/nvidia-open/nvidia-open-535.129.03-kernel4.14.322-246.539.amzn2.x86_64-x86_64.dkms.tar.gz
+ echo 'loading from /var/lib/dkms-archive/nvidia-open/nvidia-open-535.129.03-kernel4.14.322-246.539.amzn2.x86_64-x86_64.dkms.tar.gz'
loading from /var/lib/dkms-archive/nvidia-open/nvidia-open-535.129.03-kernel4.14.322-246.539.amzn2.x86_64-x86_64.dkms.tar.gz
+ /usr/sbin/dkms ldtarball /var/lib/dkms-archive/nvidia-open/nvidia-open-535.129.03-kernel4.14.322-246.539.amzn2.x86_64-x86_64.dkms.tar.gz
...
DKMS: install completed.
+ sudo systemctl daemon-reload
+ /usr/sbin/dkms status -m nvidia
nvidia, 535.129.03, 4.14.322-246.539.amzn2.x86_64, x86_64: installed
```

New tests cover the changes: no

### Description for the changelog
Add open source nvidia kernel module .tar file and install script.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
