### PR TITLE
Add script to check for security update of given ami

### DIFF
--- a/check-update-security.sh
+++ b/check-update-security.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+set -eio pipefail
+
+usage() {
+    echo "Usage:"
+    echo "  $0 AMI_PLATFORM"
+    echo "Example:"
+    echo "  $0 al2_arm"
+    echo "AMI_PLATFORM Must be one of: al1, al2, al2_arm, al2023, al2023_arm"
+}
+
+error_msg() {
+    local msg="$1"
+    echo "ERROR: $msg"
+}
+
+# Paths to get the ami ids from ssm params
+AL1_PATH="/aws/service/ecs/optimized-ami/amazon-linux/recommended"
+AL2_PATH="/aws/service/ecs/optimized-ami/amazon-linux-2/recommended"
+AL2_ARM_PATH="/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended"
+AL2023_PATH="/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended"
+AL2023_ARM_PATH="/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended"
+
+# Indicates that an update exists
+UPDATE_EXISTS_CODE="100"
+# Indicates that a wait operation failed
+WAIT_FAIL_CODE="255"
+# Indicates success
+SUCCESS_CODE="0"
+
+# In case of failure, terminate instance
+failure_cleanup() {
+    terminate_out=$(aws ec2 terminate-instances --instance-ids $instance_id)
+}
+
+check_wait_response() {
+    local wait_response=$1
+    if [ "$wait_response" -eq "$WAIT_FAIL_CODE" ]; then
+        error_msg "Failed to launch instance, instance timeout"
+        exit 1
+    fi
+}
+
+platform=$1
+if [ -z "$platform" ]; then
+    error_msg "Must specify an AMI platform"
+    usage
+    exit 1
+fi
+if [ -z "$IAM_INSTANCE_PROFILE_ARN" ]; then
+    error_msg "IAM_INSTANCE_PROFILE_ARN environment variable must exist"
+    exit 1
+fi
+
+# Get ecs-optimized ami's PATH in ssm parameters
+platform=$1
+skip_user_data=0
+instance_type="c5.large"
+install_and_start_ssm_agent=0
+case "$platform" in
+"al1")
+    ami_path=$AL1_PATH
+    install_and_start_ssm_agent=1 # AL1 Requires Installation of SSM Agent
+    ;;
+"al2")
+    ami_path=$AL2_PATH
+    ;;
+"al2_arm")
+    ami_path=$AL2_ARM_PATH
+    instance_type="c6g.medium"
+    ;;
+"al2023")
+    ami_path=$AL2023_PATH
+    skip_user_data=1
+    ;;
+"al2023_arm")
+    ami_path=$AL2023_ARM_PATH
+    skip_user_data=1
+    instance_type="c6g.medium"
+    ;;
+*)
+    error_msg "Incorrect platform selection"
+    usage
+    exit 1
+    ;;
+esac
+
+# Query ssm to get latest ecs optimized ami
+ami_id=$(aws ssm get-parameters --names $ami_path --region us-west-2 | jq -r '.Parameters[0].Value' | jq -r '.image_id')
+
+user_data=$(mktemp user_data.txt)
+if [ "$install_and_start_ssm_agent" -eq 1 ]; then
+
+    cat <<EOT >>user_data.txt
+Content-Type: multipart/mixed; boundary="//"
+MIME-Version: 1.0
+
+--//
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config.txt"
+
+#cloud-config
+repo_upgrade: none
+
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="userdata.txt"
+
+#!/bin/bash
+cd /tmp
+sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+sudo start amazon-ssm-agent
+--//--
+EOT
+
+else
+    echo "#cloud-config" >>user_data.txt
+    echo "repo_upgrade: none" >>user_data.txt
+fi
+
+# Launch ec2 instance with given ami and SSM access for command execution
+# Also get instance id
+if [ $skip_user_data -eq 0 ]; then
+    # Modify user data to ignore automatic updates by al and al2
+    instance_id=$(aws ec2 run-instances \
+        --image-id $ami_id \
+        --instance-type $instance_type \
+        --iam-instance-profile Arn=$IAM_INSTANCE_PROFILE_ARN \
+        --user-data file://user_data.txt |
+        jq -r '.Instances[0].InstanceId')
+    command_params='commands=["yum check-update --security --sec-severity=critical --exclude=nvidia*,docker*,cuda*,containerd* -q"]'
+else
+    # In the case that we have al2023, we need to send a separate style of command
+    instance_id=$(aws ec2 run-instances \
+        --image-id $ami_id \
+        --instance-type $instance_type \
+        --iam-instance-profile Arn=$IAM_INSTANCE_PROFILE_ARN |
+        jq -r '.Instances[0].InstanceId')
+    distribution_release_al2023=$(curl -s https://al2023-repos-us-west-2-de612dc2.s3.dualstack.us-west-2.amazonaws.com/core/releasemd.xml |
+        xmllint --xpath "string(//root/releases/release[last()]/@version)" -)
+    command_params='commands=["sudo dnf check-update --releasever='$distribution_release_al2023' --security --sec-severity=Critical --exclude=nvidia*,docker*,cuda*,containerd* -q"]'
+fi
+
+# Wait for instance status to reach ok, fail at timeout code
+aws ec2 wait instance-running --instance-ids $instance_id
+check_wait_response $(echo $?)
+
+# Instance has been launched, terminate in case of an error
+trap 'failure_cleanup' ERR
+
+rm "$user_data"
+
+# Assert that ssm agent is running before moving forward
+ssm_agent_status() {
+    aws ssm describe-instance-information \
+        --instance-information-filter-list key=InstanceIds,valueSet=$instance_id \
+        --query 'InstanceInformationList[0].PingStatus' --output text
+}
+max_retries=10
+success=0
+for ((r = 0; r < max_retries; r++)); do
+    if [ "$(ssm_agent_status)" = "Online" ]; then
+        success=1
+        break
+    fi
+    sleep 10
+done
+if [ $success -ne 1 ]; then
+    echo "SSM Agent connection timed out"
+    failure_cleanup
+    exit 1
+fi
+
+# Send command
+cmd_id=$(aws ssm send-command \
+    --document-name 'AWS-RunShellScript' \
+    --parameters "$command_params" \
+    --targets Key=instanceids,Values=$instance_id \
+    --comment "run security check" |
+    jq -r '.Command.CommandId')
+
+# Wait for command to be executed
+command_status() {
+    aws ssm get-command-invocation \
+        --command-id $cmd_id \
+        --instance-id $instance_id \
+        --query 'Status' \
+        --output text
+}
+max_retries=20
+success=0
+for ((r = 0; r < max_retries; r++)); do
+    cmd_status=$(command_status)
+    if [ "$cmd_status" = "Failed" ] || [ "$cmd_status" = "Success" ]; then
+        success=1
+        break
+    fi
+    sleep 5
+done
+if [ $success -ne 1 ]; then
+    echo "Command execution timed out"
+    failure_cleanup
+    exit 1
+fi
+
+# Get command output
+cmd_response_code=$(aws ssm get-command-invocation \
+    --command-id $cmd_id \
+    --instance-id $instance_id |
+    jq -r '.ResponseCode')
+
+# Delete the instance
+terminate_out=$(aws ec2 terminate-instances --instance-ids $instance_id)
+
+# Return whether update is necessary
+if [ "$cmd_response_code" -eq "$UPDATE_EXISTS_CODE" ]; then
+    echo "true"
+elif [ "$cmd_response_code" -ne "$SUCCESS_CODE" ]; then
+    # If update doesn't exist and there was a fail code, something went wrong
+    echo "Unknown issue with the command execution"
+    exit 1
+else
+    echo "false"
+fi
+
+exit 0


### PR DESCRIPTION
### Summary
This change adds a script to check for a security update based on a given ami ID. 

### Implementation details
The shell script launches an EC2 instance with the specified AMI ID and checks for updates using SSM run command. The response of the command is relayed so the caller of this script is notified whether an update is necessary for the specified AMI. 

### Testing
Tested in developer environment. 
IAM_INSTANCE_ROLE environment variable was setup to allow EC2 to launch SSM Agent

The below amis were tested by hardcoding, indicating updates by returning true.

Test: ami_id="ami-0df7393b3a1210727" #OLD AL1 AMI
Result: true
Test: ami_id="ami-04e6179c63d17513d" # OLD AL2 AMI
Result: true
Test: ami_id="ami-0c972b8adbd52bea0" # OLD AL2_ARM AMI
Result: true
Test: ami_id="ami-000e1cfd42f014991" # OLD Al2023 AMI
Result: true
Test: ami_id="ami-0ea6d2eabb53617c8" # OLD AL2023_ARM
Result: true

The actual usage of the script being tested: 

Test: ./check-update-security al1
Result: false
Test: ./check-update-security al2
Result: false
Test: ./check-update-security al2_arm
Result: false
Test: ./check-update-security al2023
Result: true 
Test: ./check-update-security al2023_arm
Result: true

Note that al2023 abd a2023_arm do have updates as of the latest time of testing

AL1 issue: SSM agent needed to be installed and run with user_data modification due to AL1 not starting it automatically even with the role setup. This change is reflected in the code.

### Description for the changelog
Feature - add script to check AMI security update

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
