### PR TITLE
ssm logs cleanup: skip shredding files since we're deleting the entire directory

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -104,14 +104,6 @@ if [[ $(sudo find {{workingDirectory}}/TOE_* -type d | sudo wc -l) -gt 0 ]]; the
 fi
 
 echo "Cleaning up ssm log files"
-if [[ $(sudo find /var/log/amazon/ssm -type f | sudo wc -l) -gt 0 ]]; then
-    echo "Deleting files within /var/log/amazon/ssm/*"
-    sudo find /var/log/amazon/ssm -type f -exec shred -zuf {} \;
-fi
-if [[ $(sudo find /var/log/amazon/ssm -type f | sudo wc -l) -gt 0 ]]; then
-    echo "Failed to delete /var/log/amazon/ssm"
-    exit 1
-fi
 if sudo test -d "/var/log/amazon/ssm"; then
     echo "Deleting /var/log/amazon/ssm/*"
     sudo rm -rf /var/log/amazon/ssm


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR makes a change to the cleanup script. In this script, while cleaning up SSM log files, we first shred the files and then delete the entire directory. We do this as per https://docs.aws.amazon.com/imagebuilder/latest/userguide/security-best-practices.html#post-build-cleanup.

Building an AMI using `make al2023` based off the latest main branch fails with the following error:
```
    amazon-ebs.al2023: Deleting files within /var/log/amazon/ssm/*
==> amazon-ebs.al2023: + sudo find /var/log/amazon/ssm -type f -exec shred -zuf '{}' ';'
==> amazon-ebs.al2023: shred: /var/log/amazon/ssm/patch-baseline-operations/botocore/data/apigateway/2015-07-09/paginators-1.json: failed to remove: No such file or directory
==> amazon-ebs.al2023: find: ‘/var/log/amazon/ssm/patch-baseline-operations/botocore/data/forecast’: No such file or directory
==> amazon-ebs.al2023: find: ‘/var/log/amazon/ssm/patch-baseline-operations/botocore/data/health’: No such file or directory
==> amazon-ebs.al2023: find: ‘/var/log/amazon/ssm/patch-baseline-operations/botocore/data/cloudhsm’: No such file or directory
==> amazon-ebs.al2023: find: ‘/var/log/amazon/ssm/patch-baseline-operations/botocore/data/secretsmanager’: No such file or directory
==> amazon-ebs.al2023: find: ‘/var/log/amazon/ssm/patch-baseline-operations/botocore/data/meteringmarketplace’: No such file or directory
==> amazon-ebs.al2023: find: ‘/var/log/amazon/ssm/patch-baseline-operations/botocore/data/config’: No such file or directory
...
...
```

This does not happen consistently, but enough times for it to potentially cause us problems (7/10 times in my local testing).

### Implementation details
<!-- How are the changes implemented? -->
During cleanup, we delete the entire `/var/log/amazon/ssm` directory. Right after deleting the directory, we also verify that the directory doesn't exist anymore, so the shredding steps are not really needed.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

- make al2 and make al2023 to build AL2 and AL2023 test AMIs.
- launched an instance using the the test AMIs verified that there are no leftover SSM logs from build time.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement: skip shredding files since we're deleting the entire directory

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
