### PR TITLE
Change generate-release-vars.sh to update specific release files

### DIFF
--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -3,9 +3,10 @@ set -eio pipefail
 
 usage() {
     echo "Usage:"
-    echo "  $0 ECS_INIT_VERSION AMI_VERSION"
+    echo "  $0 AMI_TYPE"
     echo "Example:"
-    echo "  $0 1.55.0-1 20210902"
+    echo "  $0 al2"
+    echo "AMI_TYPE Must be one of: al1, al2, al2023"
 }
 
 error() {
@@ -15,80 +16,79 @@ error() {
     exit 1
 }
 
-readonly ecs_init_version="$1"
-if [ -z "$ecs_init_version" ]; then
-    error "ecs-init version is required."
-fi
-readonly ami_version="$2"
-if [ -z "$ami_version" ]; then
-    error "ami version is required."
+readonly ami_type="$1"
+if [ -z "$ami_type" ]; then
+    error "AMI_TYPE must be provided"
 fi
 
-agent_version=$(echo "$ecs_init_version" | awk -F "-" '{ print $1 }')
-ecs_init_rev=$(echo "$ecs_init_version" | awk -F "-" '{ print $2 }')
-readonly agent_version ecs_init_rev
-if [ -z "$ecs_init_rev" ]; then
-    error "ecs-init rev was empty, did you forget the dash in ECS_INIT_VERSION? ie, 1.55.0-1"
-fi
-if [ -z "$agent_version" ]; then
-    error "agent version was empty, seems that your ECS_INIT_VERSION was malformed, it should look like: 1.55.0-1"
-fi
+readonly ami_version=$(date +"%Y%m%d")
 
 # this can be any region, as we use it to grab the latest AL2 AMI name so it should be the same across regions.
 readonly region="us-west-2"
 
-set -x
+# Get the latest source AMI names (based on type)
+case "$ami_type" in
+"al1")
+    # AL1
+    ami_id_al1=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-ebs --query 'Parameters[0].[Value]' --output text)
+    ami_name_al1=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al1" --query 'Images[0].Name' --output text)
 
-# Get the latest source AMI names
-# AL1
-ami_id_al1=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-ebs --query 'Parameters[0].[Value]' --output text)
-ami_name_al1=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al1" --query 'Images[0].Name' --output text)
+    readonly ami_name_al1
 
-# AL2
-ami_id_al2_x86=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-x86_64-ebs --query 'Parameters[0].[Value]' --output text)
-ami_name_al2_x86=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2_x86" --query 'Images[0].Name' --output text)
-ami_id_al2_arm=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-arm64-ebs --query 'Parameters[0].[Value]' --output text)
-ami_name_al2_arm=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2_arm" --query 'Images[0].Name' --output text)
-ami_id_al2_kernel5dot10=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-x86_64-ebs --query 'Parameters[0].[Value]' --output text)
-ami_name_al2_kernel5dot10=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2_x86" --query 'Images[0].Name' --output text)
-ami_id_al2_kernel5dot10arm=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-arm64-ebs --query 'Parameters[0].[Value]' --output text)
-ami_name_al2_kernel5dot10arm=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2_arm" --query 'Images[0].Name' --output text)
-
-# AL2023
-ami_id_al2023_x86=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64 --query 'Parameters[0].[Value]' --output text)
-ami_name_al2023_x86=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2023_x86" --query 'Images[0].Name' --output text)
-kernel_version_al2023_x86=$(grep -o -e "-kernel-[1-9.]*" <<<"$ami_name_al2023_x86")
-
-# AL2023 ARM
-ami_id_al2023_arm=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64 --query 'Parameters[0].[Value]' --output text)
-ami_name_al2023_arm=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2023_arm" --query 'Images[0].Name' --output text)
-kernel_version_al2023_arm=$(grep -o -e "-kernel-[1-9.]*" <<<"$ami_name_al2023_arm")
-
-# Get the latest AL2023 distribution release
-# Ref: https://docs.aws.amazon.com/linux/al2023/ug/managing-repos-os-updates.html
-# xmllint is required to find the latest distribution release from releasemd.xml in us-west-2
-distribution_release_al2023=$(curl -s https://al2023-repos-us-west-2-de612dc2.s3.dualstack.us-west-2.amazonaws.com/core/releasemd.xml | xmllint --xpath "string(//root/releases/release[last()]/@version)" -)
-
-readonly ami_name_al2_kernel5dot10arm ami_name_al2_kernel5dot10 ami_name_al2_arm ami_name_al2_x86 ami_name_al1 ami_name_al2023_arm ami_name_al2023_x86 distribution_release_al2023
-
-# Temporarily override base AMI for AL2 GPU due to a known al2 kernel and EFA/Nvidia incompatibility
-cat >|release.auto.pkrvars.hcl <<EOF
-ami_version          = "$ami_version"
-ecs_agent_version    = "$agent_version"
-ecs_init_rev         = "$ecs_init_rev"
-docker_version       = "20.10.25"
-docker_version_al2023 = "20.10.25"
-containerd_version   = "1.6.19"
-containerd_version_al2023 = "1.6.19"
-source_ami_al1       = "$ami_name_al1"
-source_ami_al2       = "$ami_name_al2_x86"
-source_ami_al2arm    = "$ami_name_al2_arm"
-source_ami_al2kernel5dot10    = "$ami_name_al2_kernel5dot10"
-source_ami_al2kernel5dot10arm = "$ami_name_al2_kernel5dot10arm"
-source_ami_al2_gpu   = "amzn2-ami-minimal-hvm-2.0.20230926.0-x86_64-ebs"
-source_ami_al2023    = "$ami_name_al2023_x86"
-source_ami_al2023arm = "$ami_name_al2023_arm"
-kernel_version_al2023    = "$kernel_version_al2023_x86"
-kernel_version_al2023arm = "$kernel_version_al2023_arm"
-distribution_release_al2023  = "$distribution_release_al2023"
+    cat >|release-al1.auto.pkrvars.hcl <<EOF
+ami_version     = "$ami_version"
+source_ami_al1  = "$ami_name_al1"
 EOF
+    ;;
+"al2")
+    # AL2
+    ami_id_al2_x86=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-x86_64-ebs --query 'Parameters[0].[Value]' --output text)
+    ami_name_al2_x86=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2_x86" --query 'Images[0].Name' --output text)
+    ami_id_al2_arm=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-arm64-ebs --query 'Parameters[0].[Value]' --output text)
+    ami_name_al2_arm=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2_arm" --query 'Images[0].Name' --output text)
+    ami_id_al2_kernel5dot10=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-x86_64-ebs --query 'Parameters[0].[Value]' --output text)
+    ami_name_al2_kernel5dot10=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2_x86" --query 'Images[0].Name' --output text)
+    ami_id_al2_kernel5dot10arm=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-arm64-ebs --query 'Parameters[0].[Value]' --output text)
+    ami_name_al2_kernel5dot10arm=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2_arm" --query 'Images[0].Name' --output text)
+
+    readonly ami_name_al2_kernel5dot10arm ami_name_al2_kernel5dot10 ami_name_al2_arm ami_name_al2_x86
+
+    cat >|release-al2.auto.pkrvars.hcl <<EOF
+ami_version                     = "$ami_version"
+source_ami_al2                  = "$ami_name_al2_x86"
+source_ami_al2arm               = "$ami_name_al2_arm"
+source_ami_al2kernel5dot10      = "$ami_name_al2_kernel5dot10"
+source_ami_al2kernel5dot10arm   = "$ami_name_al2_kernel5dot10arm"
+EOF
+    ;;
+"al2023")
+    # AL2023
+    ami_id_al2023_x86=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64 --query 'Parameters[0].[Value]' --output text)
+    ami_name_al2023_x86=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2023_x86" --query 'Images[0].Name' --output text)
+    kernel_version_al2023_x86=$(grep -o -e "-kernel-[1-9.]*" <<<"$ami_name_al2023_x86")
+
+    # AL2023 ARM
+    ami_id_al2023_arm=$(aws ssm get-parameters --region "$region" --names /aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64 --query 'Parameters[0].[Value]' --output text)
+    ami_name_al2023_arm=$(aws ec2 describe-images --region "$region" --owner amazon --image-id "$ami_id_al2023_arm" --query 'Images[0].Name' --output text)
+    kernel_version_al2023_arm=$(grep -o -e "-kernel-[1-9.]*" <<<"$ami_name_al2023_arm")
+
+    # Get the latest AL2023 distribution release
+    # Ref: https://docs.aws.amazon.com/linux/al2023/ug/managing-repos-os-updates.html
+    # xmllint is required to find the latest distribution release from releasemd.xml in us-west-2
+    distribution_release_al2023=$(curl -s https://al2023-repos-us-west-2-de612dc2.s3.dualstack.us-west-2.amazonaws.com/core/releasemd.xml | xmllint --xpath "string(//root/releases/release[last()]/@version)" -)
+
+    readonly ami_name_al2023_x86 ami_name_al2023_arm distribution_release_al2023
+
+    cat >|release-al2023.auto.pkrvars.hcl <<EOF
+ami_version                 = "$ami_version"
+source_ami_al2023           = "$ami_name_al2023_x86"
+source_ami_al2023arm        = "$ami_name_al2023_arm"
+kernel_version_al2023       = "$kernel_version_al2023_x86"
+kernel_version_al2023arm    = "$kernel_version_al2023_arm"
+distribution_release_al2023 = "$distribution_release_al2023"
+EOF
+    ;;
+*)
+    error "Incorrect AMI Selection"
+    ;;
+esac


### PR DESCRIPTION
### Summary
These changes to generate-release-vars.sh reflect the changes done in [this commit](https://github.com/aws/amazon-ecs-ami/commit/35af16d95614f3a1937e73b634cba413f509a147). The script will now update the specific file instead of the previously existing general file for base AMI versions. The script will have to be run for each variant of AMI: AL1, AL2, and AL2023. This change is for internal reasons and allows for more flexibility for desired changes. 

### Implementation details
Instead the general all AMIs file, a switch case, taking the AMI type, will determine which file to update, and will only run the commands and API calls necessary to get the information for updating that specific file. 

The agent and ecs-init versions are not needed based on the files' structures as of now. A future change, based on the implementation choice of Generate Config github action, may require us to add this. If necessary, that will be done alongside the fitting implementation. 

### Testing
The script was run for all 3 types of AMIs, and each successfully updated the desired file. 

./generate-release-vars.sh al1   => updated release-al1.auto.pkrvars.hcl
date correctly updated, base amis of latest date were correctly updated

./generate-release-vars.sh al2   => updated release-al2.auto.pkrvars.hcl
date correctly updated, base amis of latest date were correctly updated

./generate-release-vars.sh al2023   => updated release-al2023.auto.pkrvars.hcl
date correctly updated, base amis of latest date were correctly updated

New tests cover the changes: yes

### Description for the changelog
generate-release-vars.sh refactor: updates specified AMI type's release config file

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
