### PR TITLE
Add generateConfig action, updates to check-update-security and generate-release-vars.sh

### DIFF
--- a/.github/workflows/generateconfig.yml
+++ b/.github/workflows/generateconfig.yml
@@ -1,0 +1,37 @@
+name: GenerateConfig
+
+on: workflow_dispatch
+
+jobs:
+  GenerateConfig:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    env: 
+      IAM_INSTANCE_PROFILE_ARN: ${{secrets.IAM_INSTANCE_PROFILE_ARN}} 
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install xmllint
+      run: sudo apt-get update && sudo apt-get install libxml2-utils
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with: 
+        role-to-assume: ${{secrets.AMI_GENERATE_CONFIG_ROLE}}
+        aws-region: us-west-2
+    - name: Configure prereqs
+      run: |
+        git config --global user.name "GenerateConfig Action"
+        git config --global user.email "gcaction@github.com"
+    - name: Check AL1 Updates
+      run: ./scripts/check-update.sh al1
+    - name: Check AL2 Base AMI Update
+      run: ./scripts/check-update.sh al2
+    - name: Check AL2023 Base AMI Update
+      run: ./scripts/check-update.sh al2023
+    - name: Commit and Push Changes if Update Is Required
+      run: |
+        git commit -m "Release Kickoff"
+        git status
+        git push

--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -35,9 +35,16 @@ case "$ami_type" in
 
     readonly ami_name_al1
 
+    readonly ecs_version_al1=$(sed -n '/variable "ecs_version_al1" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly docker_version_al1=$(sed -n '/variable "docker_version_al1" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly exec_ssm_version=$(sed -n '/variable "exec_ssm_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+
     cat >|release-al1.auto.pkrvars.hcl <<EOF
-ami_version     = "$ami_version"
-source_ami_al1  = "$ami_name_al1"
+ami_version        = "$ami_version"
+ecs_version_al1    = "$ecs_version_al1"
+docker_version_al1 = "$docker_version_al1"
+exec_ssm_version   = "$exec_ssm_version"
+source_ami_al1     = "$ami_name_al1"
 EOF
     ;;
 "al2")
@@ -53,12 +60,23 @@ EOF
 
     readonly ami_name_al2_kernel5dot10arm ami_name_al2_kernel5dot10 ami_name_al2_arm ami_name_al2_x86
 
+    readonly ecs_agent_version=$(sed -n '/variable "ecs_agent_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly ecs_init_rev=$(sed -n '/variable "ecs_init_rev" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly docker_version=$(sed -n '/variable "docker_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly containerd_version=$(sed -n '/variable "containerd_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly exec_ssm_version=$(sed -n '/variable "exec_ssm_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+
     cat >|release-al2.auto.pkrvars.hcl <<EOF
-ami_version                     = "$ami_version"
-source_ami_al2                  = "$ami_name_al2_x86"
-source_ami_al2arm               = "$ami_name_al2_arm"
-source_ami_al2kernel5dot10      = "$ami_name_al2_kernel5dot10"
-source_ami_al2kernel5dot10arm   = "$ami_name_al2_kernel5dot10arm"
+ami_version                   = "$ami_version"
+ecs_agent_version             = "$ecs_agent_version"
+ecs_init_rev                  = "$ecs_init_rev"
+docker_version                = "$docker_version"
+containerd_version            = "$containerd_version"
+exec_ssm_version              = "$exec_ssm_version"
+source_ami_al2                = "$ami_name_al2_x86"
+source_ami_al2arm             = "$ami_name_al2_arm"
+source_ami_al2kernel5dot10    = "$ami_name_al2_kernel5dot10"
+source_ami_al2kernel5dot10arm = "$ami_name_al2_kernel5dot10arm"
 EOF
     ;;
 "al2023")
@@ -79,8 +97,19 @@ EOF
 
     readonly ami_name_al2023_x86 ami_name_al2023_arm distribution_release_al2023
 
+    readonly ecs_agent_version=$(sed -n '/variable "ecs_agent_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly ecs_init_rev=$(sed -n '/variable "ecs_init_rev" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly docker_version_2023=$(sed -n '/variable "docker_version_al2023" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly containerd_version_al2023=$(sed -n '/variable "containerd_version_al2023" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly exec_ssm_version=$(sed -n '/variable "exec_ssm_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+
     cat >|release-al2023.auto.pkrvars.hcl <<EOF
 ami_version                 = "$ami_version"
+ecs_agent_version           = "$ecs_agent_version"
+ecs_init_rev                = "$ecs_init_rev"
+docker_version_al2023       = "$docker_version_al2023"
+containerd_version_al2023   = "$containerd_version_al2023"
+exec_ssm_version            = "$exec_ssm_version"
 source_ami_al2023           = "$ami_name_al2023_x86"
 source_ami_al2023arm        = "$ami_name_al2023_arm"
 kernel_version_al2023       = "$kernel_version_al2023_x86"

--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -99,7 +99,7 @@ EOF
 
     readonly ecs_agent_version=$(sed -n '/variable "ecs_agent_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
     readonly ecs_init_rev=$(sed -n '/variable "ecs_init_rev" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
-    readonly docker_version_2023=$(sed -n '/variable "docker_version_al2023" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly docker_version_al2023=$(sed -n '/variable "docker_version_al2023" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
     readonly containerd_version_al2023=$(sed -n '/variable "containerd_version_al2023" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
     readonly exec_ssm_version=$(sed -n '/variable "exec_ssm_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
 

--- a/release-al1.auto.pkrvars.hcl
+++ b/release-al1.auto.pkrvars.hcl
@@ -1,2 +1,5 @@
-ami_version    = "20231024"
-source_ami_al1 = "amzn-ami-minimal-hvm-2018.03.0.20231002.0-x86_64-ebs"
+ami_version        = "20231205"
+ecs_version_al1    = "1.51.0"
+docker_version_al1 = "20.10.13"
+exec_ssm_version   = "3.2.1630.0"
+source_ami_al1     = "amzn-ami-minimal-hvm-2018.03.0.20231106.0-x86_64-ebs"

--- a/scripts/check-update-security.sh
+++ b/scripts/check-update-security.sh
@@ -89,7 +89,7 @@ esac
 # Query ssm to get latest ecs optimized ami
 ami_id=$(aws ssm get-parameters --names $ami_path --region us-west-2 | jq -r '.Parameters[0].Value' | jq -r '.image_id')
 
-user_data=$(mktemp user_data.txt)
+user_data=$(touch user_data.txt)
 if [ "$install_and_start_ssm_agent" -eq 1 ]; then
 
     cat <<EOT >>user_data.txt
@@ -153,7 +153,7 @@ check_wait_response $(echo $?)
 # Instance has been launched, terminate in case of an error
 trap 'failure_cleanup' ERR
 
-rm "$user_data"
+rm user_data.txt
 
 # Assert that ssm agent is running before moving forward
 ssm_agent_status() {
@@ -195,12 +195,12 @@ command_status() {
 max_retries=20
 success=0
 for ((r = 0; r < max_retries; r++)); do
+    sleep 5
     cmd_status=$(command_status)
     if [ "$cmd_status" = "Failed" ] || [ "$cmd_status" = "Success" ]; then
         success=1
         break
     fi
-    sleep 5
 done
 if [ $success -ne 1 ]; then
     echo "Command execution timed out"

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -io pipefail
+
+usage() {
+    echo "Usage:"
+    echo "  $0 AMI_TYPE"
+    echo "Example:"
+    echo "  $0 al2"
+    echo "AMI_TYPE Must be one of: al1, al2, al2023"
+}
+
+error() {
+    local msg="$1"
+    echo "ERROR: $msg"
+    usage
+    exit 1
+}
+
+readonly ami_type="$1"
+if [ -z "$ami_type" ]; then
+    error "AMI_TYPE must be provided"
+fi
+
+cp release-$ami_type.auto.pkrvars.hcl release-$ami_type.old.hcl
+./generate-release-vars.sh $ami_type
+diff_val=$(diff <(grep -v ami_version release-$ami_type.old.hcl) <(grep -v ami_version release-$ami_type.auto.pkrvars.hcl))
+if [ -z "$diff_val" ]; then
+    Update=$(./scripts/check-update-security.sh $ami_type)
+    if [ "$Update" != "true" ] && [ "$ami_type" != "al1" ]; then
+        Update=$(./scripts/check-update-security.sh "$ami_type"_arm)
+    fi
+else
+    Update="true"
+fi
+
+rm "release-$ami_type.old.hcl"
+
+if [ "$Update" = "true" ]; then
+    echo "Update exists for $ami_type"
+    git add release-$ami_type.auto.pkrvars.hcl
+else
+    echo "Update does not exist for $ami_type"
+fi


### PR DESCRIPTION
### Summary
Add generate config github action. The action checks runs ./generate-release-vars.sh, sees if there are any dependency updates, and pushes to the repository in the case of a release needing to be kicked off. If no dependency updates exist, it will fall back to checking security updates by launching an ec2 instance with the AMIs and checking for critical updates.

Also includes a couple modifications to the check update security script to make it more resilient to API errors, that occurred in a couple rare test scenarios. 

### Implementation details
The action was split into steps of a github action, and runs on workflow dispatch as of now. 

### Testing
A testing document was made to check all important test scenarios. 

New tests cover the changes: yes

### Description for the changelog
Add GenerateConfig github action

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
