### PR TITLE
exclude airgapped regions from open kmod build

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support.sh
+++ b/scripts/enable-ecs-agent-gpu-support.sh
@@ -26,8 +26,8 @@ EOF
 # the amzn2-nvidia repo is temporary and only used for installing the system-release-nvidia package
 sudo mv $tmpfile /etc/yum.repos.d/amzn2-nvidia-tmp.repo
 
-# only install open driver for post-kepler gpus
-if [[ $AMI_TYPE != "al2keplergpu" ]]; then
+# only install open driver for post-kepler gpus, exclude airgapped regions
+if [[ $AMI_TYPE != "al2keplergpu" && -z ${AIR_GAPPED} ]]; then
     sudo yum install -y yum-plugin-versionlock \
         yum-utils
     sudo amazon-linux-extras install epel -y


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This excludes airgapped regions from attempting to access the open internet to pull the open kernel module.

### Implementation details
the air_gapped env var defaults to the empty string ""
```
variable "air_gapped" {
  type        = string
  description = "If this build is for an air-gapped region, set to 'true'"
  default     = ""
}
```
we check for the empty string with the `-z "${AIR_GAPPED}"` which returns true for a zero length string.
so we want to check that the ami type is NOT kepler based, and that the AIR_GAPPED variable IS zero length (ie not set).  Both need to be true in order to build the open module.
```
if [[ $AMI_TYPE != "al2keplergpu" && -z "${AIR_GAPPED}" ]]
```

### Testing
https://paste.amazon.com/show/fierlion/1702319606

New tests cover the changes: 

### Description for the changelog
Exclude air gapped region from building open kmod.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
