### PR TITLE
Add security update install script in build recipe for al1 and al2

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -137,6 +137,13 @@ build {
   }
 
   provisioner "shell" {
+    inline_shebang = "/bin/sh -ex"
+    inline = [
+      "sudo yum update -y --security --sec-severity=critical --exclude=nvidia*,docker*,cuda*,containerd*"
+    ]
+  }
+
+  provisioner "shell" {
     script = "scripts/cleanup.sh"
   }
 

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -203,6 +203,13 @@ build {
   }
 
   provisioner "shell" {
+    inline_shebang = "/bin/sh -ex"
+    inline = [
+      "sudo yum update -y --security --sec-severity=critical --exclude=nvidia*,docker*,cuda*,containerd*"
+    ]
+  }
+
+  provisioner "shell" {
     script = "scripts/cleanup.sh"
   }
 


### PR DESCRIPTION
### Summary
This change makes it so that a packer build of AL1 or AL2 (all flavors) automatically run security updates. 

### Implementation details
A step was added into the build for AL1 and AL2 that runs a line of bash to update the security packages. This was not needed for AL2023, because it is version locked, and security updates are only applicable by using a new distribution release. Since a new distribution release is already installed in the recipe for AL2023, we need not have a specific security update step. 

### Testing
After running make al1, and al2, the images were successfully built, and the additional sudo yum update... bash line was run during the build without errors. 

### Description for the changelog
Addition to build recipe of AL1 and AL2 to update security packages during build. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
