### PR TITLE
use ami_name_al2_x86 for gpu base ami

### DIFF
--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -15,7 +15,7 @@ source "amazon-ebs" "al2gpu" {
   region = var.region
   source_ami_filter {
     filters = {
-      name = "${var.source_ami_al2_gpu}"
+      name = "${var.source_ami_al2}"
     }
     owners      = ["amazon"]
     most_recent = true

--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -71,7 +71,6 @@ distribution_release_al2023=$(curl -s https://al2023-repos-us-west-2-de612dc2.s3
 
 readonly ami_name_al2_kernel5dot10arm ami_name_al2_kernel5dot10 ami_name_al2_arm ami_name_al2_x86 ami_name_al1 ami_name_al2023_arm ami_name_al2023_x86 distribution_release_al2023
 
-# Temporarily override base AMI for AL2 GPU due to a known al2 kernel and EFA/Nvidia incompatibility
 cat >|release.auto.pkrvars.hcl <<EOF
 ami_version          = "$ami_version"
 ecs_agent_version    = "$agent_version"
@@ -85,7 +84,6 @@ source_ami_al2       = "$ami_name_al2_x86"
 source_ami_al2arm    = "$ami_name_al2_arm"
 source_ami_al2kernel5dot10    = "$ami_name_al2_kernel5dot10"
 source_ami_al2kernel5dot10arm = "$ami_name_al2_kernel5dot10arm"
-source_ami_al2_gpu   = "amzn2-ami-minimal-hvm-2.0.20230926.0-x86_64-ebs"
 source_ami_al2023    = "$ami_name_al2023_x86"
 source_ami_al2023arm = "$ami_name_al2023_arm"
 kernel_version_al2023    = "$kernel_version_al2023_x86"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -87,11 +87,6 @@ variable "source_ami_al2arm" {
   description = "Amazon Linux 2 ARM source AMI to build from."
 }
 
-variable "source_ami_al2_gpu" {
-  type        = string
-  description = "Amazon Linux 2 source AMI to build AL2GPU AMI from."
-}
-
 variable "source_ami_al2kernel5dot10" {
   type        = string
   description = "Amazon Linux 2 Kernel 5.10 source AMI to build from."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This updates the generate release vars script to use AL2/x86 as the base GPU AMI

### Implementation details
Update the script to use `ami_name_al2_x86` as the source_ami_al2_gpu

### Description for the changelog
Revert pinned gpu base AMI.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
