### PR TITLE
Reduce default AMI size

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ If you would like to override any of the defaults provided here without committi
 can use the `overrides.auto.pkrvars.hcl` file, which is ignored by source control.
 
 For example, if you want your AMI to have a smaller root block device, you can override the default value
-of 30 GB like this:
+of 4 GB like this:
 
 ```
 export REGION=us-west-2
-echo "block_device_size_gb = 8" > ./overrides.auto.pkrvars.hcl
+echo "block_device_size_gb = 3" > ./overrides.auto.pkrvars.hcl
 make al2
 ```
 

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -37,7 +37,7 @@ variable "region" {
 
 variable "block_device_size_gb" {
   type        = number
-  default     = 30
+  default     = 4
   description = "Size of the root block device."
 }
 


### PR DESCRIPTION
### Summary
The default size of 30 GB is excessive, so reduce to 4 GB. This removes the need to build a custom AMI every time just to override the size.

### Implementation details
Changed default variable value.

### Testing
We have been building custom AMIs using an override for this value for months successfully.

### Description for the changelog
Enhancement - Reduce default AMI size

### Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.