### PR TITLE
Remove unnecessary security update checks for al2023

### DIFF
--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -24,10 +24,14 @@ fi
 cp release-$ami_type.auto.pkrvars.hcl release-$ami_type.old.hcl
 ./generate-release-vars.sh $ami_type
 diff_val=$(diff <(grep -v ami_version release-$ami_type.old.hcl) <(grep -v ami_version release-$ami_type.auto.pkrvars.hcl))
+# If no difference in dependencies, check for security update
 if [ -z "$diff_val" ]; then
-    Update=$(./scripts/check-update-security.sh $ami_type)
-    if [ "$Update" != "true" ] && [ "$ami_type" != "al1" ]; then
-        Update=$(./scripts/check-update-security.sh "$ami_type"_arm)
+    # al2023 version already generates a diff in dependency file if it has security updates, so no check necessary if al2023
+    if [ "$ami_type" != "al2023" ]; then
+        Update=$(./scripts/check-update-security.sh $ami_type)
+        if [ "$Update" != "true" ] && [ "$ami_type" != "al1" ]; then
+            Update=$(./scripts/check-update-security.sh "$ami_type"_arm)
+        fi
     fi
 else
     Update="true"


### PR DESCRIPTION
### Summary
In a feature implementation for AMI release, two scripts were added under scripts in the repository that, working together, checked whether any of the AMI types require an update and complete necessary steps to automatically kick off a release. After writing it, it was noticed that AL2023 security updates come with the latest version of AL2023, and therefore it is redundant to check for security updates in a separate script if the version of AL2023 is already detected to have an update. Therefore, the implementation for check-update-security.sh was modified to not include AL2023 as a possible check, and check-update.sh was modified to not run check-update-security.sh with al2023 argument. 

### Implementation details
The changes are in scripts/check-update.sh and scripts/check-update-security.sh. The change in check-update.sh removes an unnecessary call to check-update-security.sh with al2023 argument. The change in check-update-security.sh removes unnecessary implementation of al2023 security update check path.

### Testing
Manually ran scripts, with the following results:

check-update no longer calls to check-update-security.sh with al2023 argument, and check-update-security.sh no longer accepts the al2023 arguments. 

New tests cover the changes: yes

### Description for the changelog
Remove redundant al2023 update checks

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
