### PR TITLE
Refactor generate release notes script for enhanced release process

### DIFF
--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -2,56 +2,245 @@
 
 set -eo pipefail
 
+# Flags
+AL2_GPU_NVIDIA_VERSION=""
+AL2_GPU_CUDA_VERSION=""
+AL1_CONTAINERD_VERSION=""
+EXCLUDE_AMI=""
+
 usage() {
-    echo "Usage:"
-    echo "  $0 AL2_GPU_NVIDIA_VERSION AL2_GPU_CUDA_VERSION [AL1_CONTAINERD_VERSION]"
-    echo "  AL1_CONTAINERD_VERSION should not be provided if there is no AL1 AMI release"
-    echo "Example:"
-    echo "  $0 470.182.03 11.4 1.4.13 # AL1 release included"
-    echo "  $0 470.182.03 11.4        # No AL1 release"
+    cat <<-EOF
+Usage:
+  $0
+
+Options:
+	--al2-gpu-nvidia-ver  (Optional) AL2 GPU NVIDIA version. If specified, then --al2-gpu-cuda-ver option is also required to be specified.
+	--al2-gpu-cuda-ver    (Optional) AL2 GPU CUDA version. If specified, then  --al2-gpu-nvidia optin is also required to be specified.
+	--al1-containerd-ver  (Optional) AL1 containerd version.
+	--exclude-ami         (Optional) comma separated list of AMI variants that are excluded in the release.
+
+Example:
+  $0 --al2-gpu-nvidia-ver 000.00.00 --al2-gpu-cuda-ver 00.0.0 --al1-containerd-ver 0.0.0 --exclude-ami al2023neu,al2inf
+EOF
 }
 
-# Parameters
-al2_gpu_nvidia_version=$1
-al2_gpu_cuda_version=$2
-al1_containerd_version=$3 # Optional, will include AL1 in the release notes if provided
+main() {
+    parse_args "$@"
+    validate_args
+    generate_release_notes
+}
 
-if [ "$al2_gpu_nvidia_version" == "" ]; then
-    echo "Error: AL2 GPU NVIDIA version is empty"
-    usage
-    exit 1
-fi
-if [ "$al2_gpu_cuda_version" == "" ]; then
-    echo "Error: AL2 GPU CUDA version is empty"
-    usage
-    exit 1
-fi
+# Parses the options specified for the script.
+parse_args() {
+    while :; do
+        case $1 in
+        --al2-gpu-nvidia-ver)
+            AL2_GPU_NVIDIA_VERSION="$2"
+            shift
+            ;;
+        --al2-gpu-cuda-ver)
+            AL2_GPU_CUDA_VERSION="$2"
+            shift
+            ;;
+        --al1-containerd-ver)
+            AL1_CONTAINERD_VERSION="$2"
+            shift
+            ;;
+        --exclude-ami)
+            EXCLUDE_AMI="$2"
+            shift
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        --) # End of options.
+            shift
+            break
+            ;;
+        *) # Default case: No more options - break out of the loop.
+            break ;;
+        esac
+        shift
+    done
+}
 
-# Read some information from pkrvars file
-readonly pkrvars="release.auto.pkrvars.hcl"
-readonly ami_version=$(cat $pkrvars | grep -w 'ami_version' | cut -d '"' -f2)
-readonly containerd_version_al2023=$(cat $pkrvars | grep -w 'containerd_version_al2023' | cut -d '"' -f2)
-readonly distribution_release_al2023=$(cat $pkrvars | grep -w 'distribution_release_al2023' | cut -d '"' -f2)
-readonly containerd_version=$(cat $pkrvars | grep -w 'containerd_version' | cut -d '"' -f2)
+# Validates the options specified for the script.
+validate_args() {
+    if [ -z "$AL2_GPU_CUDA_VERSION" ] || [ -z "$AL2_GPU_NVIDIA_VERSION" ]; then
+        if ! is_ami_excluded "al2gpu"; then
+            printf "Error: AL2 GPU CUDA version or AL2 GPU NVIDIA version is empty when releasing AL2 GPU\n\n"
+            usage
+            exit 1
+        fi
+    fi
+    if [ -z "$AL1_CONTAINERD_VERSION" ] && ! is_ami_excluded "al1"; then
+        printf "Error: AL1 containerd version is empty when releasing AL1\n\n"
+        usage
+        exit 1
+    fi
+}
 
-if [ -z "$ami_version" ]; then
-    echo "Error: AMI version was not found in $pkrvars"
-    exit 1
-fi
-if [ -z "$containerd_version_al2023" ]; then
-    echo "Error: Containerd version was not found for AL2023 in $pkrvars"
-    exit 1
-fi
-if [ -z "$distribution_release_al2023" ]; then
-    echo "Error: Distribution release version was not found for AL2023 in $pkrvars"
-    exit 1
-fi
-if [ -z "$containerd_version" ]; then
-    echo "Error: Containerd version was not found in $pkrvars"
-    exit 1
-fi
+# Generates the relevant notes for the release.
+generate_release_notes() {
+    # Below file contains containerd version information for AL2023 and AL2 AMIs
+    readonly variablespkr="variables.pkr.hcl"
 
-# Gets ECS Optimized AMI details from SSM parameter store given the paramter name.
+    # Determine AMI version from pkrvars files
+    placeholder_version="00000000"
+    ami_version="$placeholder_version"
+    readonly al2023pkrvars="release-al2023.auto.pkrvars.hcl"
+    readonly al2pkrvars="release-al2.auto.pkrvars.hcl"
+    readonly al1pkrvars="release-al1.auto.pkrvars.hcl"
+    pkvars_files="$al2023pkrvars $al2pkrvars $al1pkrvars"
+    for file in $pkvars_files; do
+        file_ami_version=$(cat $file | grep -w 'ami_version' | cut -d '"' -f2)
+        if [[ $file_ami_version -gt $ami_version ]]; then
+            ami_version="$file_ami_version"
+        fi
+    done
+
+    if [ "$ami_version" == "$placeholder_version" ]; then
+        echo "Error: AMI version was not found in files $pkvars_files"
+        exit 1
+    fi
+
+    # Prepare release notes
+    release_notes="### Source AMI release notes
+---
+* [Amazon Linux 2023 release notes](https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html)
+* [Amazon Linux 2 release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)
+* [Amazon Linux release notes](https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes)
+
+### Changelog
+---
+https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#$ami_version
+"
+
+    # AL2023
+    if ! { is_ami_excluded "al2023" && is_ami_excluded "al2023arm" && is_ami_excluded "al2023neu"; }; then
+        # Get AL2023 AMI family details
+        readonly containerd_version_al2023=$(cat $variablespkr | sed -n '/containerd_version_al2023"/,/}/p' | grep -w 'default' | cut -d '"' -f2)
+        readonly distribution_release_al2023=$(cat $al2023pkrvars | grep -w 'distribution_release_al2023' | cut -d '"' -f2)
+        if [ -z "$containerd_version_al2023" ]; then
+            echo "Error: Containerd version was not found for AL2023 in $al2023pkrvars"
+            exit 1
+        fi
+        if [ -z "$distribution_release_al2023" ]; then
+            echo "Error: Distribution release version was not found for AL2023 in $al2023pkrvars"
+            exit 1
+        fi
+
+        # AL2023 Header
+        al2023_header="
+### Amazon ECS-optimized Amazon Linux 2023 AMI
+---"
+        release_notes="${release_notes}${al2023_header}"
+
+        # Include AL2023 AMD64 release notes if there was an al2023 release
+        if ! is_ami_excluded "al2023"; then
+            # AL2023 AMD64 AMI details
+            read ami_name_al2023_x86 agent_version_al2023_x86 docker_version_al2023_x86 source_ami_name_al2023_x86 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended")
+            add_ami_to_release_notes "#### AMD64" "$ami_name_al2023_x86" "$agent_version_al2023_x86" "$docker_version_al2023_x86" "$containerd_version_al2023" "" "" "$source_ami_name_al2023_x86" "$distribution_release_al2023"
+        fi
+
+        # Include AL2023 ARM64 release notes if there was an al2023arm release
+        if ! is_ami_excluded "al2023arm"; then
+            # AL2023 ARM64 AMI details
+            read ami_name_al2023_arm agent_version_al2023_arm docker_version_al2023_arm source_ami_name_al2023_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended")
+            add_ami_to_release_notes "#### ARM64" "$ami_name_al2023_arm" "$agent_version_al2023_arm" "$docker_version_al2023_arm" "$containerd_version_al2023" "" "" "$source_ami_name_al2023_arm" "$distribution_release_al2023"
+        fi
+
+        # Include AL2023 Neuron release notes if there was an al2023neu release
+        if ! is_ami_excluded "al2023neu"; then
+            # AL2023 Neuron AMI details
+            read ami_name_al2023_neuron agent_version_al2023_neuron docker_version_al2023_neuron source_ami_name_al2023_neuron <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2023/neuron/recommended")
+            add_ami_to_release_notes "#### Neuron" "$ami_name_al2023_neuron" "$agent_version_al2023_neuron" "$docker_version_al2023_neuron" "$containerd_version_al2023" "" "" "$source_ami_name_al2023_neuron" "$distribution_release_al2023"
+        fi
+    fi
+
+    # AL2
+    if ! { is_ami_excluded "al2" && is_ami_excluded "al2arm" && is_ami_excluded "al2inf" && is_ami_excluded "al2gpu" &&
+        is_ami_excluded "al2kernel5dot10" && is_ami_excluded "al2kernel5dot10arm"; }; then
+        # Get AL2 AMI family details
+        readonly containerd_version=$(cat $variablespkr | sed -n '/containerd_version"/,/}/p' | grep -w 'default' | cut -d '"' -f2)
+        if [ -z "$containerd_version" ]; then
+            echo "Error: Containerd version was not found in $variablespkr"
+            exit 1
+        fi
+
+        # AL2 Header
+        al2_header="
+### Amazon ECS-optimized Amazon Linux 2 AMI
+---"
+        release_notes="${release_notes}${al2_header}"
+
+        # Include AL2 AMD64 (Kernel 4.14) release notes if there was an al2 release
+        if ! is_ami_excluded "al2"; then
+            # AL2 AMD64 (Kernel 4.14) AMI details
+            read ami_name_al2_x86 agent_version_al2_x86 docker_version_al2_x86 source_ami_name_al2_x86 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended")
+            add_ami_to_release_notes "#### AMD64 (Kernel 4.14)" "$ami_name_al2_x86" "$agent_version_al2_x86" "$docker_version_al2_x86" "$containerd_version" "" "" "$source_ami_name_al2_x86" ""
+        fi
+
+        # Include AL2 ARM64 (Kernel 4.14) release notes if there was an al2arm release
+        if ! is_ami_excluded "al2arm"; then
+            # AL2 ARM64 (Kernel 4.14) AMI details
+            read ami_name_al2_arm agent_version_al2_arm docker_version_al2_arm source_ami_name_al2_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended")
+            add_ami_to_release_notes "#### ARM64 (Kernel 4.14)" "$ami_name_al2_arm" "$agent_version_al2_arm" "$docker_version_al2_arm" "$containerd_version" "" "" "$source_ami_name_al2_arm" ""
+        fi
+
+        # Include AL2 Neuron release notes if there was an al2inf release
+        if ! is_ami_excluded "al2inf"; then
+            # AL2 Neuron AMI details
+            read ami_name_al2_inf agent_version_al2_inf docker_version_al2_inf source_ami_name_al2_inf <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/inf/recommended")
+            add_ami_to_release_notes "#### Neuron (Kernel 4.14)" "$ami_name_al2_inf" "$agent_version_al2_inf" "$docker_version_al2_inf" "$containerd_version" "" "" "$source_ami_name_al2_inf" ""
+        fi
+
+        # Include AL2 GPU release notes if there was an al2gpu release
+        if ! is_ami_excluded "al2gpu"; then
+            # AL2 GPU AMI details
+            read ami_name_al2_gpu agent_version_al2_gpu docker_version_al2_gpu source_ami_name_al2_gpu <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended")
+            add_ami_to_release_notes "#### GPU (Kernel 4.14)" "$ami_name_al2_gpu" "$agent_version_al2_gpu" "$docker_version_al2_gpu" "$containerd_version" "$AL2_GPU_NVIDIA_VERSION" "$AL2_GPU_CUDA_VERSION" "$source_ami_name_al2_gpu" ""
+        fi
+
+        # Include AL2 AMD64 (Kernel 5.10) release notes if there was an al2kernel5dot10 release
+        if ! is_ami_excluded "al2kernel5dot10"; then
+            # AL2 AMD64 (Kernel 5.10) AMI details
+            read ami_name_al2_kernel_5_10 agent_version_al2_kernel_5_10 docker_version_al2_kernel_5_10 source_ami_name_al2_kernel_5_10 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/kernel-5.10/recommended")
+            add_ami_to_release_notes "#### AMD64 (Kernel 5.10)" "$ami_name_al2_kernel_5_10" "$agent_version_al2_kernel_5_10" "$docker_version_al2_kernel_5_10" "$containerd_version" "" "" "$source_ami_name_al2_kernel_5_10" ""
+        fi
+
+        # Include AL2 ARM64 (Kernel 5.10) release notes if there was an al2kernel5dot10arm release
+        if ! is_ami_excluded "al2kernel5dot10arm"; then
+            # AL2 ARM64 (Kernel 5.10) AMI details
+            read ami_name_al2_kernel_5_10_arm agent_version_al2_kernel_5_10_arm docker_version_al2_kernel_5_10_arm source_ami_name_al2_kernel_5_10_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/kernel-5.10/arm64/recommended")
+            add_ami_to_release_notes "#### ARM64 (Kernel 5.10)" "$ami_name_al2_kernel_5_10_arm" "$agent_version_al2_kernel_5_10_arm" "$docker_version_al2_kernel_5_10_arm" "$containerd_version" "" "" "$source_ami_name_al2_kernel_5_10_arm" ""
+        fi
+    fi
+
+    # AL1
+    # Include AL1 release notes if there was an al1 release
+    if ! is_ami_excluded "al1"; then
+        al1_header="
+### Amazon ECS-optimized Amazon Linux AMI
+---"
+        release_notes="${release_notes}${al1_header}"
+
+        read ami_name_al1 agent_version_al1 docker_version_al1 source_ami_name_al1 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux/recommended")
+        add_ami_to_release_notes "The Amazon ECS-optimized Amazon Linux AMI is deprecated as of April 15, 2021. After that date, Amazon ECS will continue providing critical and important security updates for the AMI but will not add support for new features.
+" "$ami_name_al1" "$agent_version_al1" "$docker_version_al1" "$AL1_CONTAINERD_VERSION" "" "" "$source_ami_name_al1" ""
+    fi
+
+    echo -n "$release_notes"
+}
+
+# Checks if a given AMI variant is excluded in the release.
+is_ami_excluded() {
+    local ami="$1"
+    echo "$EXCLUDE_AMI" | grep -wq "$ami"
+}
+
+# Gets ECS Optimized AMI details from SSM parameter store given the parameter name.
 # Uses the default AWS credentials as the parameter is public and can be
 # fetched from a standard region (us-west-2 is used).
 get_ami_details() {
@@ -64,120 +253,49 @@ get_ami_details() {
     echo "$ami_name $agent_version $docker_version $source_ami_name"
 }
 
-# AL2023 AMI details
-read ami_name_al2023_x86 agent_version_al2023_x86 docker_version_al2023_x86 source_ami_name_al2023_x86 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended")
-read ami_name_al2023_arm agent_version_al2023_arm docker_version_al2023_arm source_ami_name_al2023_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended")
-read ami_name_al2023_neuron agent_version_al2023_neuron docker_version_al2023_neuron source_ami_name_al2023_neuron <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2023/neuron/recommended")
+# Adds a given AMI variant to the release notes.
+add_ami_to_release_notes() {
+    local subheader="$1" # Optional (i.e., "" is allowed)
+    local name="$2"
+    local agent_ver="$3"
+    local docker_ver="$4"
+    local containerd_ver="$5"
+    local nvidia_ver="$6" # Optional (i.e., "" is allowed)
+    local cuda_ver="$7"   # Optional (i.e., "" is allowed)
+    local source_name="$8"
+    local dist_al2023_release="$9" # Optional (i.e., "" is allowed)
 
-# AL2 AMI details
-read ami_name_al2_x86 agent_version_al2_x86 docker_version_al2_x86 source_ami_name_al2_x86 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended")
-read ami_name_al2_arm agent_version_al2_arm docker_version_al2_arm source_ami_name_al2_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended")
-read ami_name_al2_gpu agent_version_al2_gpu docker_version_al2_gpu source_ami_name_al2_gpu <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended")
-read ami_name_al2_inf agent_version_al2_inf docker_version_al2_inf source_ami_name_al2_inf <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/inf/recommended")
-read ami_name_al2_kernel_5_10 agent_version_al2_kernel_5_10 docker_version_al2_kernel_5_10 source_ami_name_al2_kernel_5_10 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/kernel-5.10/recommended")
-read ami_name_al2_kernel_5_10_arm agent_version_al2_kernel_5_10_arm docker_version_al2_kernel_5_10_arm source_ami_name_al2_kernel_5_10_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/kernel-5.10/arm64/recommended")
+    if [ -n "$subheader" ]; then
+        release_notes="${release_notes}
+${subheader}"
+    fi
 
-# AL1 AMI details
-read ami_name_al1 agent_version_al1 docker_version_al1 source_ami_name_al1 <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux/recommended")
+    release_notes="${release_notes}
+- AMI name: $name
+- ECS Agent version: [$agent_ver](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_ver)
+- Docker version: $docker_ver
+- Containerd version: $containerd_ver"
 
-# Prepare release notes
-release_notes="### Source AMI release notes
----
-* [Amazon Linux 2023 release notes](https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html)
-* [Amazon Linux 2 release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)
-* [Amazon Linux release notes](https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes)
+    if [ -n "$nvidia_ver" ]; then
+        release_notes="${release_notes}
+- NVIDIA driver version: $nvidia_ver"
+    fi
 
-### Changelog
----
-https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#$ami_version
+    if [ -n "$cuda_ver" ]; then
+        release_notes="${release_notes}
+- CUDA version: $cuda_ver"
+    fi
 
-### Amazon ECS-optimized Amazon Linux 2023 AMI
----
-#### AMD64
-- AMI name: $ami_name_al2023_x86
-- ECS Agent version: [$agent_version_al2023_x86](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2023_x86)
-- Docker version: $docker_version_al2023_x86
-- Containerd version: $containerd_version_al2023
-- Source AMI name: $source_ami_name_al2023_x86
-- Distribution al2023 release: $distribution_release_al2023
+    release_notes="${release_notes}
+- Source AMI name: $source_name"
 
-#### ARM64
-- AMI name: $ami_name_al2023_arm
-- ECS Agent version: [$agent_version_al2023_arm](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2023_arm)
-- Docker version: $docker_version_al2023_arm
-- Containerd version: $containerd_version_al2023
-- Source AMI name: $source_ami_name_al2023_arm
-- Distribution al2023 release: $distribution_release_al2023
+    if [ -n "$dist_al2023_release" ]; then
+        release_notes="${release_notes}
+- Distribution al2023 release: $dist_al2023_release"
+    fi
 
-#### Neuron
-- AMI name: $ami_name_al2023_neuron
-- ECS Agent version: [$agent_version_al2023_neuron](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2023_neuron)
-- Docker version: $docker_version_al2023_neuron
-- Containerd version: $containerd_version_al2023
-- Source AMI name: $source_ami_name_al2023_neuron
-- Distribution al2023 release: $distribution_release_al2023
+    release_notes="${release_notes}
+"
+}
 
-### Amazon ECS-optimized Amazon Linux 2 AMI
----
-#### AMD64 (Kernel 4.14)
-- AMI name: $ami_name_al2_x86
-- ECS Agent version: [$agent_version_al2_x86](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_x86)
-- Docker version: $docker_version_al2_x86
-- Containerd version: $containerd_version
-- Source AMI name: $source_ami_name_al2_x86
-
-#### ARM64 (Kernel 4.14)
-- AMI name: $ami_name_al2_arm
-- ECS Agent version: [$agent_version_al2_arm](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_arm)
-- Docker version: $docker_version_al2_arm
-- Containerd version: $containerd_version
-- Source AMI name: $source_ami_name_al2_arm
-
-#### Neuron (Kernel 4.14)
-- AMI name: $ami_name_al2_inf
-- ECS Agent version: [$agent_version_al2_inf](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_inf)
-- Docker version: $docker_version_al2_inf
-- Containerd version: $containerd_version
-- Source AMI name: $source_ami_name_al2_inf
-
-#### GPU (Kernel 4.14)
-- AMI name: $ami_name_al2_gpu
-- ECS Agent version: [$agent_version_al2_gpu](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_gpu)
-- Docker version: $docker_version_al2_gpu
-- Containerd version: $containerd_version
-- NVIDIA driver version: $al2_gpu_nvidia_version
-- CUDA version: $al2_gpu_cuda_version
-- Source AMI name: $source_ami_name_al2_gpu
-
-#### AMD64 (Kernel 5.10)
-- AMI name: $ami_name_al2_kernel_5_10
-- ECS Agent version: [$agent_version_al2_kernel_5_10](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_kernel_5_10)
-- Docker version: $docker_version_al2_kernel_5_10
-- Containerd version: $containerd_version
-- Source AMI name: $source_ami_name_al2_kernel_5_10
-
-#### ARM64 (Kernel 5.10)
-- AMI name: $ami_name_al2_kernel_5_10_arm
-- ECS Agent version: [$agent_version_al2_kernel_5_10_arm](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al2_kernel_5_10_arm)
-- Docker version: $docker_version_al2_kernel_5_10_arm
-- Containerd version: $containerd_version
-- Source AMI name: $source_ami_name_al2_kernel_5_10_arm"
-
-# Include AL1 release notes if there was an AL1 release
-if [ -n "$al1_containerd_version" ]; then
-    al1_release_notes="
-
-### Amazon ECS-optimized Amazon Linux AMI
----
-The Amazon ECS-optimized Amazon Linux AMI is deprecated as of April 15, 2021. After that date, Amazon ECS will continue providing critical and important security updates for the AMI but will not add support for new features.
-
-- AMI name: $ami_name_al1
-- ECS Agent version: [$agent_version_al1](https://github.com/aws/amazon-ecs-agent/releases/tag/v$agent_version_al1)
-- Docker version: $docker_version_al1
-- Containerd version: $al1_containerd_version
-- Source AMI name: $source_ami_name_al1"
-
-    release_notes="${release_notes}${al1_release_notes}"
-fi
-
-echo "$release_notes"
+main "$@"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Refactor generate release notes script (i.e., `generate-release-notes.sh`) to fit with the enhanced release process being worked on in branch `feature/shinkansen`.

**NOTE:** This pull request will be merged into branch `feature/shinkansen`.

### Implementation details
<!-- How are the changes implemented? -->
- Take in options/flags instead of having set arguments with a specific order for AL2 NVIDIA version, AL2 CUDA version, and AL1 containerd version
- Make AL2 NVIDIA version and AL2 CUDA version options optional, as with the enhanced release process AL2 GPU AMIs may not necessarily be released during every AMI release
- Define new option/flag `--exclude-ami` to specify what AMI variants are excluded in a given release, as with the enhanced release process any given AMI variant may not necessarily be included
- Only generate release notes for AMI variants that are included as part of the release
- Take into account information / file structure changes made to release variables as part of https://github.com/aws/amazon-ecs-ami/pull/167
- Update script usage information according to the changes made
- For better readability and organization, define a `main` function and group commands living outside of a function into more granular functions

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Manually pulled in the most recent release variables information from branch `main` and then tested: 
- generating release notes for `20231219` release using `./generate-release-notes.sh --al2-gpu-nvidia-ver 535.129.03 --al2-gpu-cuda-ver 12.2.2 --al1-containerd-ver 1.4.13` command and comparing the generated release notes against [the expected release notes](https://github.com/aws/amazon-ecs-ami/releases/tag/20231219) using `diff`. No differences were found

<details>

<summary>Generated output</summary>

```
### Source AMI release notes
---
* [Amazon Linux 2023 release notes](https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html)
* [Amazon Linux 2 release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)
* [Amazon Linux release notes](https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes)

### Changelog
---
https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#20231219

### Amazon ECS-optimized Amazon Linux 2023 AMI
---
#### AMD64
- AMI name: al2023-ami-ecs-hvm-2023.0.20231219-kernel-6.1-x86_64
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: al2023-ami-minimal-2023.3.20231218.0-kernel-6.1-x86_64
- Distribution al2023 release: 2023.3.20231218

#### ARM64
- AMI name: al2023-ami-ecs-hvm-2023.0.20231219-kernel-6.1-arm64
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: al2023-ami-minimal-2023.3.20231218.0-kernel-6.1-arm64
- Distribution al2023 release: 2023.3.20231218

#### Neuron
- AMI name: al2023-ami-ecs-neuron-hvm-2023.0.20231219-kernel-6.1-x86_64
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: al2023-ami-minimal-2023.3.20231218.0-kernel-6.1-x86_64
- Distribution al2023 release: 2023.3.20231218

### Amazon ECS-optimized Amazon Linux 2 AMI
---
#### AMD64 (Kernel 4.14)
- AMI name: amzn2-ami-ecs-hvm-2.0.20231219-x86_64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-x86_64-ebs

#### ARM64 (Kernel 4.14)
- AMI name: amzn2-ami-ecs-hvm-2.0.20231219-arm64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-arm64-ebs

#### Neuron (Kernel 4.14)
- AMI name: amzn2-ami-ecs-inf-hvm-2.0.20231219-x86_64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-x86_64-ebs

#### GPU (Kernel 4.14)
- AMI name: amzn2-ami-ecs-gpu-hvm-2.0.20231219-x86_64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- NVIDIA driver version: 535.129.03
- CUDA version: 12.2.2
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-x86_64-ebs

#### AMD64 (Kernel 5.10)
- AMI name: amzn2-ami-ecs-kernel-5.10-hvm-2.0.20231219-x86_64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-x86_64-ebs

#### ARM64 (Kernel 5.10)
- AMI name: amzn2-ami-ecs-kernel-5.10-hvm-2.0.20231219-arm64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-arm64-ebs

### Amazon ECS-optimized Amazon Linux AMI
---
The Amazon ECS-optimized Amazon Linux AMI is deprecated as of April 15, 2021. After that date, Amazon ECS will continue providing critical and important security updates for the AMI but will not add support for new features.

- AMI name: amzn-ami-2018.03.20231219-amazon-ecs-optimized
- ECS Agent version: [1.51.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.51.0)
- Docker version: 20.10.13
- Containerd version: 1.4.13
- Source AMI name: amzn-ami-minimal-hvm-2018.03.0.20231218.0-x86_64-ebs
```

</details>

- generating release notes using the  `--exclude-ami` option/flag and confirming that the excluded AMI variants specified using that option are not included in the generated output

<details>

<summary>Example test</summary>

### Input

```
./generate-release-notes.sh --al2-gpu-nvidia-ver 000.00.00 --al2-gpu-cuda-ver 00.0.0 --al1-containerd-ver 0.0.0 --exclude-ami al2023neu,al2inf
```

### Output

```
### Source AMI release notes
---
* [Amazon Linux 2023 release notes](https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html)
* [Amazon Linux 2 release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)
* [Amazon Linux release notes](https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes)

### Changelog
---
https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#20231219

### Amazon ECS-optimized Amazon Linux 2023 AMI
---
#### AMD64
- AMI name: al2023-ami-ecs-hvm-2023.0.20231219-kernel-6.1-x86_64
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: al2023-ami-minimal-2023.3.20231218.0-kernel-6.1-x86_64
- Distribution al2023 release: 2023.3.20231218

#### ARM64
- AMI name: al2023-ami-ecs-hvm-2023.0.20231219-kernel-6.1-arm64
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: al2023-ami-minimal-2023.3.20231218.0-kernel-6.1-arm64
- Distribution al2023 release: 2023.3.20231218

### Amazon ECS-optimized Amazon Linux 2 AMI
---
#### AMD64 (Kernel 4.14)
- AMI name: amzn2-ami-ecs-hvm-2.0.20231219-x86_64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-x86_64-ebs

#### ARM64 (Kernel 4.14)
- AMI name: amzn2-ami-ecs-hvm-2.0.20231219-arm64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-arm64-ebs

#### GPU (Kernel 4.14)
- AMI name: amzn2-ami-ecs-gpu-hvm-2.0.20231219-x86_64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- NVIDIA driver version: 000.00.00
- CUDA version: 00.0.0
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-x86_64-ebs

#### AMD64 (Kernel 5.10)
- AMI name: amzn2-ami-ecs-kernel-5.10-hvm-2.0.20231219-x86_64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-x86_64-ebs

#### ARM64 (Kernel 5.10)
- AMI name: amzn2-ami-ecs-kernel-5.10-hvm-2.0.20231219-arm64-ebs
- ECS Agent version: [1.79.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.79.2)
- Docker version: 20.10.25
- Containerd version: 1.6.19
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20231218.0-arm64-ebs

### Amazon ECS-optimized Amazon Linux AMI
---
The Amazon ECS-optimized Amazon Linux AMI is deprecated as of April 15, 2021. After that date, Amazon ECS will continue providing critical and important security updates for the AMI but will not add support for new features.

- AMI name: amzn-ami-2018.03.20231219-amazon-ecs-optimized
- ECS Agent version: [1.51.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.51.0)
- Docker version: 20.10.13
- Containerd version: 0.0.0
- Source AMI name: amzn-ami-minimal-hvm-2018.03.0.20231218.0-x86_64-ebs
```

</details>

- incorrect usage (i.e., not passing in AL2 GPU NVIDIA version when AL2 GPU release is required and/or AL2 GPU CUDA version is provided, not passing in AL2 GPU CUDA version when AL2 GPU release is required and/or AL2 GPU NVIDIA version is provided, not passing in AL1 containerd version when AL1 release is required, etc.)

<details>

<summary>Example test</summary>

### Input

```
./generate-release-notes.sh --al2-gpu-cuda-ver 00.0.00 --exclude-ami al2023,al2023arm,al2023neu,al1
```

### Output

```
Error: AL2 GPU CUDA version or AL2 GPU NVIDIA version is empty when releasing AL2 GPU

Usage:
  ./generate-release-notes.sh

Options:
--al2-gpu-nvidia-ver  (Optional) AL2 GPU NVIDIA version. If specified, then --al2-gpu-cuda-ver option is also required to be specified.
--al2-gpu-cuda-ver    (Optional) AL2 GPU CUDA version. If specified, then  --al2-gpu-nvidia optin is also required to be specified.
--al1-containerd-ver  (Optional) AL1 containerd version.
--exclude-ami         (Optional) comma separated list of AMI variants that are excluded in the release.

Example:
  ./generate-release-notes.sh --al2-gpu-nvidia-ver 000.00.00 --al2-gpu-cuda-ver 00.0.0 --al1-containerd-ver 0.0.0 --exclude-ami al2023neu,al2inf
```
</details>

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Refactor generate release notes script for enhanced release process

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
