### PR TITLE
al2gpu: Remove epel repo after installing dkms and nvidia open modules

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support.sh
+++ b/scripts/enable-ecs-agent-gpu-support.sh
@@ -28,8 +28,7 @@ sudo mv $tmpfile /etc/yum.repos.d/amzn2-nvidia-tmp.repo
 
 # only install open driver for post-kepler gpus, exclude airgapped regions
 if [[ $AMI_TYPE != "al2keplergpu" && -z ${AIR_GAPPED} ]]; then
-    sudo yum install -y yum-plugin-versionlock \
-        yum-utils
+    sudo yum install -y yum-plugin-versionlock yum-utils
     sudo amazon-linux-extras install epel -y
     sudo yum install -y "kernel-devel-uname-r == $(uname -r)"
 
@@ -60,6 +59,12 @@ if [[ $AMI_TYPE != "al2keplergpu" && -z ${AIR_GAPPED} ]]; then
     sudo yum remove -y kmod-nvidia-open-dkms
     sudo yum-config-manager --disable cuda-rhel7.repo
     sudo rm /etc/yum.repos.d/cuda-rhel7.repo
+    # epel was used to install dkms, now delete as it points to public http endpoints which
+    # can cause problems for customers using isolated subnets.
+    sudo yum-config-manager --disable epel
+    sudo rm /etc/yum.repos.d/epel.repo
+    sudo rm /etc/yum.repos.d/epel-testing.repo
+    sudo amazon-linux-extras disable epel
     sudo rm -rf /var/cache/yum
     sudo yum-config-manager --enable amzn2-nvidia
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

After installing dkms and nvidia open modules, remove and cleanup the epel repo.

The reason for this is that the epel repo is a public fedora repo. The URLs of this repo require access to the open internet. Customers using isolated subnets will not have internet access so all package updates and installs will fail when yum tries talking to the epel repo.

Removing it ensures that the AMI by default only points to internal Amazon Linux repos which are accessible in isolated subnets.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

al2gpu AMI built, ran /var/lib/ecs/scripts/install-nvidia-open-kmod.sh script

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix: Fix al2gpu AMI package installs and updates when running in isolated subnets

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
