### PR TITLE
change amzn2-extras.repo file owner to root

### DIFF
--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -121,7 +121,8 @@ build {
   provisioner "shell" {
     inline_shebang = "/bin/sh -ex"
     inline = [
-      "sudo mv /tmp/amzn2-extras.repo /etc/yum.repos.d/amzn2-extras.repo"
+      "sudo mv /tmp/amzn2-extras.repo /etc/yum.repos.d/amzn2-extras.repo",
+      "sudo chown root:root /etc/yum.repos.d/amzn2-extras.repo"
     ]
   }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently, on a freshly booted instance we see following
```
[ec2-user@ip-172-31-95-15 yum.repos.d]$ ls -lh
total 8.0K
-rw-r--r-- 1 root     root     1003 Sep 26 22:32 amzn2-core.repo
-rw-r--r-- 1 ec2-user ec2-user  972 Jan 12 17:58 amzn2-extras.repo
```
The `ec2-user` user and group should not own repo configs. This PR updates owner and owner group to `root`.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no
On a freshly booted instance with test AMI built with the updated recipe, verified that 
```
[ec2-user@ip-172-31-28-12 yum.repos.d]$ ls -lh
total 8.0K
-rw-r--r-- 1 root root 1003 Sep 26 22:32 amzn2-core.repo
-rw-r--r-- 1 root root  972 Feb  7 18:16 amzn2-extras.repo

```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
change amzn2-extras.repo file owner to root

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
