### PR TITLE
Create manualtrigger.yml

### DIFF
--- a/.github/workflows/manualtrigger.yml
+++ b/.github/workflows/manualtrigger.yml
@@ -1,0 +1,36 @@
+name: ManualPushToCodeCommit
+
+on: workflow_dispatch
+
+jobs:
+  PushToCodeCommit:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with: 
+        role-to-assume: ${{secrets.AMI_MIRROR_ROLE}}
+        aws-region: us-west-2
+    - name: Delete shinkansen branch on codecommit repository
+      run: |
+        aws codecommit delete-branch --repository-name amazon-ecs-ami-mirror --branch-name shinkansen
+    - name: Configure prereqs
+      run: |
+        git config --global user.name "Github Action"
+        git config --global user.email "action@github.com"
+        pip install git-remote-codecommit
+    - name: Mirror to shinkansen branch on codecommit repository
+      run: | 
+        git clone --single-branch --branch feature/shinkansen https://github.com/aws/amazon-ecs-ami ecsAmiGithub
+        git clone codecommit::us-west-2://amazon-ecs-ami-mirror ecsAmiCodeCommit
+        cp ecsAmiCodeCommit/Config ecsAmiGithub/
+        cd ecsAmiGithub
+        git add Config
+        git commit -m "Add config"
+        git remote add codecommit codecommit::us-west-2://amazon-ecs-ami-mirror
+        git push codecommit feature/shinkansen:shinkansen


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Create a new workflow file to have the push to CodeCommit steps available for manual triggers. The human releaser would need to self-update the ami-version in the release config and then manually trigger the manual workflow GH action.


### Testing
Testing as part of the first enhanced ECS Optimized AMI release

New tests cover the changes: n/a

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Adding new workflow for manual trigger. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
