### PR TITLE
decouple ami_version across ami families

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al1 = "${var.ami_name_prefix_al1}${var.ami_version}-amazon-ecs-optimized"
+  ami_name_al1 = "${var.ami_name_prefix_al1}${var.ami_version_al1}-amazon-ecs-optimized"
 }
 
 source "amazon-ebs" "al1" {
   ami_name        = "${local.ami_name_al1}"
-  ami_description = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version_al1} x86_64 ECS HVM GP2"
   instance_type   = var.general_purpose_instance_types[0]
   launch_block_device_mappings {
     volume_size           = 8
@@ -36,7 +36,7 @@ source "amazon-ebs" "al1" {
     ecs_runtime_version = "Docker version ${var.docker_version_al1}"
     ecs_agent_version   = "${var.ecs_version_al1}"
     ami_type            = "al1"
-    ami_version         = "2018.03.${var.ami_version}"
+    ami_version         = "2018.03.${var.ami_version_al1}"
   }
 }
 

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2 = "${var.ami_name_prefix_al2}-hvm-2.0.${var.ami_version}-x86_64-ebs"
+  ami_name_al2 = "${var.ami_name_prefix_al2}-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
 }
 
 source "amazon-ebs" "al2" {
   ami_name        = "${local.ami_name_al2}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
   instance_type   = var.general_purpose_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,7 +28,7 @@ source "amazon-ebs" "al2" {
     ecs_runtime_version = "Docker version ${var.docker_version}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2"
-    ami_version         = "2.0.${var.ami_version}"
+    ami_version         = "2.0.${var.ami_version_al2}"
   }
 }
 

--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2023 = "${var.ami_name_prefix_al2023}-hvm-2023.0.${var.ami_version}${var.kernel_version_al2023}-x86_64"
+  ami_name_al2023 = "${var.ami_name_prefix_al2023}-hvm-2023.0.${var.ami_version_al2023}${var.kernel_version_al2023}-x86_64"
 }
 
 source "amazon-ebs" "al2023" {
   ami_name        = "${local.ami_name_al2023}"
-  ami_description = "Amazon Linux AMI 2023.0.${var.ami_version} x86_64 ECS HVM EBS"
+  ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} x86_64 ECS HVM EBS"
   instance_type   = var.general_purpose_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,7 +28,7 @@ source "amazon-ebs" "al2023" {
     ecs_runtime_version = "Docker version ${var.docker_version_al2023}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2023"
-    ami_version         = "2023.0.${var.ami_version}"
+    ami_version         = "2023.0.${var.ami_version_al2023}"
   }
 }
 

--- a/al2023arm.pkr.hcl
+++ b/al2023arm.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2023arm = "${var.ami_name_prefix_al2023}-hvm-2023.0.${var.ami_version}${var.kernel_version_al2023arm}-arm64"
+  ami_name_al2023arm = "${var.ami_name_prefix_al2023}-hvm-2023.0.${var.ami_version_al2023}${var.kernel_version_al2023arm}-arm64"
 }
 
 source "amazon-ebs" "al2023arm" {
   ami_name        = "${local.ami_name_al2023arm}"
-  ami_description = "Amazon Linux AMI 2023.0.${var.ami_version} arm64 ECS HVM EBS"
+  ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} arm64 ECS HVM EBS"
   instance_type   = var.arm_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,6 +28,6 @@ source "amazon-ebs" "al2023arm" {
     ecs_runtime_version = "Docker version ${var.docker_version_al2023}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2023arm"
-    ami_version         = "2023.0.${var.ami_version}"
+    ami_version         = "2023.0.${var.ami_version_al2023}"
   }
 }

--- a/al2023neu.pkr.hcl
+++ b/al2023neu.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2023neu = "${var.ami_name_prefix_al2023}-neuron-hvm-2023.0.${var.ami_version}${var.kernel_version_al2023}-x86_64"
+  ami_name_al2023neu = "${var.ami_name_prefix_al2023}-neuron-hvm-2023.0.${var.ami_version_al2023}${var.kernel_version_al2023}-x86_64"
 }
 
 source "amazon-ebs" "al2023neu" {
   ami_name        = "${local.ami_name_al2023neu}"
-  ami_description = "Amazon Linux AMI 2023.0.${var.ami_version} x86_64 ECS HVM EBS"
+  ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} x86_64 ECS HVM EBS"
   instance_type   = var.neu_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,7 +28,7 @@ source "amazon-ebs" "al2023neu" {
     ecs_runtime_version = "Docker version ${var.docker_version_al2023}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2023neu"
-    ami_version         = "2023.0.${var.ami_version}"
+    ami_version         = "2023.0.${var.ami_version_al2023}"
   }
 }
 

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2arm = "${var.ami_name_prefix_al2}-hvm-2.0.${var.ami_version}-arm64-ebs"
+  ami_name_al2arm = "${var.ami_name_prefix_al2}-hvm-2.0.${var.ami_version_al2}-arm64-ebs"
 }
 
 source "amazon-ebs" "al2arm" {
   ami_name        = "${local.ami_name_al2arm}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} arm64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} arm64 ECS HVM GP2"
   instance_type   = var.arm_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,6 +28,6 @@ source "amazon-ebs" "al2arm" {
     ecs_runtime_version = "Docker version ${var.docker_version}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2arm"
-    ami_version         = "2.0.${var.ami_version}"
+    ami_version         = "2.0.${var.ami_version_al2}"
   }
 }

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2gpu = "${var.ami_name_prefix_al2}-gpu-hvm-2.0.${var.ami_version}-x86_64-ebs"
+  ami_name_al2gpu = "${var.ami_name_prefix_al2}-gpu-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
 }
 
 source "amazon-ebs" "al2gpu" {
   ami_name        = "${local.ami_name_al2gpu}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
   instance_type   = var.gpu_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,6 +28,6 @@ source "amazon-ebs" "al2gpu" {
     ecs_runtime_version = "Docker version ${var.docker_version}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2gpu"
-    ami_version         = "2.0.${var.ami_version}"
+    ami_version         = "2.0.${var.ami_version_al2}"
   }
 }

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2inf = "${var.ami_name_prefix_al2}-inf-hvm-2.0.${var.ami_version}-x86_64-ebs"
+  ami_name_al2inf = "${var.ami_name_prefix_al2}-inf-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
 }
 
 source "amazon-ebs" "al2inf" {
   ami_name        = "${local.ami_name_al2inf}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
   instance_type   = var.inf_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,6 +28,6 @@ source "amazon-ebs" "al2inf" {
     ecs_runtime_version = "Docker version ${var.docker_version}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2inf"
-    ami_version         = "2.0.${var.ami_version}"
+    ami_version         = "2.0.${var.ami_version_al2}"
   }
 }

--- a/al2keplergpu.pkr.hcl
+++ b/al2keplergpu.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2keplergpu = "${var.ami_name_prefix_al2}-kepler-gpu-hvm-2.0.${var.ami_version}-x86_64-ebs"
+  ami_name_al2keplergpu = "${var.ami_name_prefix_al2}-kepler-gpu-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
 }
 
 source "amazon-ebs" "al2keplergpu" {
   ami_name        = "${local.ami_name_al2keplergpu}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
   instance_type   = var.gpu_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,6 +28,6 @@ source "amazon-ebs" "al2keplergpu" {
     ecs_runtime_version = "Docker version ${var.docker_version}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2keplergpu"
-    ami_version         = "2.0.${var.ami_version}"
+    ami_version         = "2.0.${var.ami_version_al2}"
   }
 }

--- a/al2kernel5dot10.pkr.hcl
+++ b/al2kernel5dot10.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2kernel5dot10 = "${var.ami_name_prefix_al2}-kernel-5.10-hvm-2.0.${var.ami_version}-x86_64-ebs"
+  ami_name_al2kernel5dot10 = "${var.ami_name_prefix_al2}-kernel-5.10-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
 }
 
 source "amazon-ebs" "al2kernel5dot10" {
   ami_name        = "${local.ami_name_al2kernel5dot10}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 x86_64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 x86_64 ECS HVM GP2"
   instance_type   = var.general_purpose_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,6 +28,6 @@ source "amazon-ebs" "al2kernel5dot10" {
     ecs_runtime_version = "Docker version ${var.docker_version}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2kernel5dot10"
-    ami_version         = "2.0.${var.ami_version}"
+    ami_version         = "2.0.${var.ami_version_al2}"
   }
 }

--- a/al2kernel5dot10arm.pkr.hcl
+++ b/al2kernel5dot10arm.pkr.hcl
@@ -1,10 +1,10 @@
 locals {
-  ami_name_al2kernel5dot10arm = "${var.ami_name_prefix_al2}-kernel-5.10-hvm-2.0.${var.ami_version}-arm64-ebs"
+  ami_name_al2kernel5dot10arm = "${var.ami_name_prefix_al2}-kernel-5.10-hvm-2.0.${var.ami_version_al2}-arm64-ebs"
 }
 
 source "amazon-ebs" "al2kernel5dot10arm" {
   ami_name        = "${local.ami_name_al2kernel5dot10arm}"
-  ami_description = "Amazon Linux AMI 2.0.${var.ami_version} Kernel 5.10 arm64 ECS HVM GP2"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 arm64 ECS HVM GP2"
   instance_type   = var.arm_instance_types[0]
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
@@ -28,6 +28,6 @@ source "amazon-ebs" "al2kernel5dot10arm" {
     ecs_runtime_version = "Docker version ${var.docker_version}"
     ecs_agent_version   = "${var.ecs_agent_version}"
     ami_type            = "al2kernel5dot10arm"
-    ami_version         = "2.0.${var.ami_version}"
+    ami_version         = "2.0.${var.ami_version_al2}"
   }
 }

--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -40,7 +40,7 @@ case "$ami_type" in
     readonly exec_ssm_version=$(sed -n '/variable "exec_ssm_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
 
     cat >|release-al1.auto.pkrvars.hcl <<EOF
-ami_version        = "$ami_version"
+ami_version_al1    = "$ami_version"
 ecs_version_al1    = "$ecs_version_al1"
 docker_version_al1 = "$docker_version_al1"
 exec_ssm_version   = "$exec_ssm_version"
@@ -67,7 +67,7 @@ EOF
     readonly exec_ssm_version=$(sed -n '/variable "exec_ssm_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
 
     cat >|release-al2.auto.pkrvars.hcl <<EOF
-ami_version                   = "$ami_version"
+ami_version_al2               = "$ami_version"
 ecs_agent_version             = "$ecs_agent_version"
 ecs_init_rev                  = "$ecs_init_rev"
 docker_version                = "$docker_version"
@@ -104,7 +104,7 @@ EOF
     readonly exec_ssm_version=$(sed -n '/variable "exec_ssm_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
 
     cat >|release-al2023.auto.pkrvars.hcl <<EOF
-ami_version                 = "$ami_version"
+ami_version_al2023          = "$ami_version"
 ecs_agent_version           = "$ecs_agent_version"
 ecs_init_rev                = "$ecs_init_rev"
 docker_version_al2023       = "$docker_version_al2023"

--- a/release-al1.auto.pkrvars.hcl
+++ b/release-al1.auto.pkrvars.hcl
@@ -1,4 +1,4 @@
-ami_version        = "20240201"
+ami_version_al1    = "20240201"
 ecs_version_al1    = "1.51.0"
 docker_version_al1 = "20.10.13"
 exec_ssm_version   = "3.2.1630.0"

--- a/release-al2.auto.pkrvars.hcl
+++ b/release-al2.auto.pkrvars.hcl
@@ -1,4 +1,4 @@
-ami_version                   = "20240207"
+ami_version_al2               = "20240207"
 ecs_agent_version             = "1.81.0"
 ecs_init_rev                  = "1"
 docker_version                = "20.10.25"

--- a/release-al2023.auto.pkrvars.hcl
+++ b/release-al2023.auto.pkrvars.hcl
@@ -1,4 +1,4 @@
-ami_version                 = "20240207"
+ami_version_al2023          = "20240207"
 ecs_agent_version           = "1.81.0"
 ecs_init_rev                = "1"
 docker_version_al2023       = "20.10.25"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -13,6 +13,12 @@ locals {
   packages_al2023 = "amazon-efs-utils amazon-ssm-agent amazon-ec2-net-utils acpid"
 }
 
+variable "ami_name_prefix_al1" {
+  type        = string
+  description = "Outputted AMI name prefix."
+  default     = "unofficial-amzn-ami-2018.03."
+}
+
 variable "ami_name_prefix_al2" {
   type        = string
   description = "Outputted AMI name prefix."
@@ -25,7 +31,17 @@ variable "ami_name_prefix_al2023" {
   default     = "unofficial-amzn2023-ami-ecs"
 }
 
-variable "ami_version" {
+variable "ami_version_al1" {
+  type        = string
+  description = "Outputted AMI version."
+}
+
+variable "ami_version_al2" {
+  type        = string
+  description = "Outputted AMI version."
+}
+
+variable "ami_version_al2023" {
   type        = string
   description = "Outputted AMI version."
 }
@@ -138,12 +154,6 @@ variable "kernel_version_al2023" {
 variable "kernel_version_al2023arm" {
   type        = string
   description = "Amazon Linux 2023 ARM kernel version."
-}
-
-variable "ami_name_prefix_al1" {
-  type        = string
-  description = "Outputted AMI name prefix."
-  default     = "unofficial-amzn-ami-2018.03."
 }
 
 variable "source_ami_al1" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR decouples ami_version across ami families. This is because we do packer inspect during our AMI builds via `./packer inspect`. This gets the `ami_version` from the last read `release-{al1/al2/al2023}.auto.pkrvars.hcl` file. Hence we need to make the ami_version a unique key across the different release configs.

### Implementation details
<!-- How are the changes implemented? -->
rename ami_version to ami_version_{al1/al2/al2023}.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> N/A

Ran ./scripts/check-update.sh to generate the release config files.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

bugfix: decouple ami_version across ami families

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
