### PR TITLE
Fix ECS_INIT_LOCAL_OVERRIDE in install-ecs-init.sh

### DIFF
--- a/scripts/install-ecs-init.sh
+++ b/scripts/install-ecs-init.sh
@@ -6,7 +6,7 @@ if [ -n "$AIR_GAPPED" ]; then
     exit 0
 fi
 
-if [ -n "$INIT_LOCAL_OVERRIDE" ]; then
+if [ -n "$ECS_INIT_LOCAL_OVERRIDE" ]; then
     echo "ecs-init is provided locally, assuming it's in additional-packages/ directory"
     exit 0
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR updates the variable name from `INIT_LOCAL_OVERRIDE` to `ECS_INIT_LOCAL_OVERRIDE` in the `install-ecs-init.sh`. (Note: This variable is introduced by the previous PR https://github.com/aws/amazon-ecs-ami/pull/40 to support installing ecs-init rpms from a local source).

### Implementation details
Use `ECS_INIT_LOCAL_OVERRIDE` in `install-ecs-init.sh`.

### Testing
1. Download ecs-init version 1.81.0 rpm to the `additional-packages` folder
2. Build an AL2 AMI with `ecs_init_local_override` set to `ecs-init-1.81.0-1.amzn2.x86_64.rpm`.
3. The AL2 AMI is built successfully, and it passed all e2e functional tests.

An sample packer log: 
```
==> amazon-ebs.al2: + mkdir /tmp/additional-packages
==> amazon-ebs.al2: Uploading additional-packages/ => /tmp/additional-packages
...
==> amazon-ebs.al2: Provisioning with shell script: scripts/install-ecs-init.sh
==> amazon-ebs.al2: + '[' -n '' ']'
==> amazon-ebs.al2: + '[' -n ecs-init-1.81.0-1.amzn2.x86_64.rpm ']'
    amazon-ebs.al2: ecs-init is provided locally, assuming it's in additional-packages/ directory
==> amazon-ebs.al2: + echo 'ecs-init is provided locally, assuming it'\''s in additional-packages/ directory'
==> amazon-ebs.al2: + exit 0
==> amazon-ebs.al2: Provisioning with shell script: scripts/install-additional-packages.sh
==> amazon-ebs.al2: ++ uname -m
==> amazon-ebs.al2: + ARCH=x86_64
==> amazon-ebs.al2: + ls /tmp/additional-packages/ecs-init-1.81.0-1.amzn2.x86_64.rpm
    amazon-ebs.al2: /tmp/additional-packages/ecs-init-1.81.0-1.amzn2.x86_64.rpm
    amazon-ebs.al2: Found additional packages with architecture x86_64 to be installed
==> amazon-ebs.al2: + echo 'Found additional packages with architecture x86_64 to be installed'
==> amazon-ebs.al2: + sudo yum localinstall -y /tmp/additional-packages/ecs-init-1.81.0-1.amzn2.x86_64.rpm
...
    amazon-ebs.al2: Installed:
    amazon-ebs.al2:   ecs-init.x86_64 0:1.81.0-1.amzn2
    amazon-ebs.al2:
    amazon-ebs.al2: Complete!
```

New tests cover the changes: no

### Description for the changelog
Fix ECS_INIT_LOCAL_OVERRIDE in install-ecs-init.sh 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
