### PR TITLE
Update generate release notes script to factor in decoupled ami_version across ami families

### DIFF
--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -106,7 +106,7 @@ generate_release_notes() {
     readonly al1pkrvars="release-al1.auto.pkrvars.hcl"
     pkvars_files="$al2023pkrvars $al2pkrvars $al1pkrvars"
     for file in $pkvars_files; do
-        file_ami_version=$(cat $file | grep -w 'ami_version' | cut -d '"' -f2)
+        file_ami_version=$(cat $file | grep 'ami_version' | cut -d '"' -f2)
         if [[ $file_ami_version -gt $ami_version ]]; then
             ami_version="$file_ami_version"
         fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update generate release notes script to take into account the changes from https://github.com/aws/amazon-ecs-ami/pull/202.

### Implementation details
<!-- How are the changes implemented? -->
See Summary above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Tested as part of generating the 20240212 release notes.

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update generate release notes script to factor in decoupled ami_version across ami families

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
