### PR TITLE
Make release action PR instead of push directly

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, these accounts
+# will be requested for review when someone opens a pull request.
+* @aws/aws-ecs-agent

--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -1,28 +1,41 @@
 name: InitiateRelease
 
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+  schedule: 
+    - cron: 0 18 * * 2
 
 jobs:
   GenerateConfig:
     runs-on: ubuntu-latest
     outputs:
-      commit_exit_code: ${{ steps.final.outputs.commit_exit_code }}
+      stage_exit_code: ${{ steps.stage.outputs.stage_exit_code }}
+      push_exit_code: ${{ steps.push.outputs.push_exit_code }}
+      pr_exit_code: ${{ steps.pr.outputs.pr_exit_code }}
     permissions:
       id-token: write
       contents: write
+      pull-requests: write
     env: 
-      IAM_INSTANCE_PROFILE_ARN: ${{secrets.IAM_INSTANCE_PROFILE_ARN}} 
+      IAM_INSTANCE_PROFILE_ARN: ${{ secrets.IAM_INSTANCE_PROFILE_ARN }} 
+      GH_TOKEN: ${{ github.token }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+    - name: Create Release Branch
+      run: |
+        date=$(date '+%Y%m%d')
+        git checkout -b release-${date}
     - name: Install xmllint
-      run: sudo apt-get update && sudo apt-get install libxml2-utils
+      run: |
+        # generate-release-vars.sh depends on these packages 
+        sudo apt-get update && sudo apt-get install libxml2-utils
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with: 
-        role-to-assume: ${{secrets.AMI_GENERATE_CONFIG_ROLE}}
+        role-to-assume: ${{ secrets.AMI_GENERATE_CONFIG_ROLE }}
         aws-region: us-west-2
-    - name: Configure prereqs
+    - name: Configure Bot Alias
       run: |
         git config --global user.name "GenerateConfig Action"
         git config --global user.email "gcaction@github.com"
@@ -32,25 +45,41 @@ jobs:
       run: ./scripts/check-update.sh al2
     - name: Check AL2023 Update
       run: ./scripts/check-update.sh al2023
-    - name: Commit and Push Changes
-      id: final
+    - name: Check for changes
+      id: stage
       run: |
+        # Git diff returns exit code of 1 when there is a change staged
+        # We need the set statements to prevent erroring out
         set +e
-        git commit -m "Release Kickoff"
-        echo "commit_exit_code=$?" >> "$GITHUB_OUTPUT"
-        git status
-        git push
+        git diff --cached --quiet 
+        echo "stage_exit_code=$?" >> "$GITHUB_OUTPUT"
         set -e
+    - name: Commit and Push Changes
+      id: push
+      if: ${{ steps.stage.outputs.stage_exit_code == 1 }}
+      run: |
+        date=$(date '+%Y%m%d')
+        git commit -m "Release ${date}"
+        git status
+        git push --set-upstream origin release-${date}
+        echo "push_exit_code=$?" >> "$GITHUB_OUTPUT"
+    - name: Open PR for Branch 
+      id: pr
+      if: ${{ steps.stage.outputs.stage_exit_code == 1 && steps.push.outputs.push_exit_code == 0 }}
+      run: |
+        date=$(date '+%Y%m%d')
+        gh pr create --base main --head release-${date} --title "Release ${date}" --body "Enhanced ECS Optimized AMI Release changes"
+        echo "pr_exit_code=$?" >> "$GITHUB_OUTPUT"
   PushToCodeCommit:
     needs: GenerateConfig
-    if: ${{ needs.GenerateConfig.outputs.commit_exit_code==0 }}
+    if: ${{ needs.GenerateConfig.outputs.stage_exit_code == 1 && needs.GenerateConfig.outputs.push_exit_code == 0 && needs.GenerateConfig.outputs.pr_exit_code == 0 }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with: 
@@ -66,14 +95,15 @@ jobs:
         pip install git-remote-codecommit
     - name: Mirror to shinkansen branch on codecommit repository
       run: | 
-        git clone --single-branch --branch main https://github.com/aws/amazon-ecs-ami ecsAmiGithub
+        date=$(date '+%Y%m%d')
+        git clone --single-branch --branch release-${date} https://github.com/aws/amazon-ecs-ami ecsAmiGithub
         git clone codecommit::us-west-2://amazon-ecs-ami-mirror ecsAmiCodeCommit
         cp ecsAmiCodeCommit/Config ecsAmiGithub/
         cd ecsAmiGithub
         git add Config
-        git commit -m "Add config"
+        git commit -m "Release ${date}"
         git remote add codecommit codecommit::us-west-2://amazon-ecs-ami-mirror
-        git push codecommit main:shinkansen
+        git push codecommit release-${date}:shinkansen
   MetricPublish:
     needs: [GenerateConfig, PushToCodeCommit]
     if: ${{ always() }}
@@ -82,6 +112,8 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with: 

--- a/.github/workflows/manualtrigger.yml
+++ b/.github/workflows/manualtrigger.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with: 
@@ -26,12 +26,13 @@ jobs:
         pip install git-remote-codecommit
     - name: Mirror to shinkansen branch on codecommit repository
       run: | 
+        date=$(date '+%Y%m%d')
         git clone --single-branch --branch main https://github.com/aws/amazon-ecs-ami ecsAmiGithub
         git clone codecommit::us-west-2://amazon-ecs-ami-mirror ecsAmiCodeCommit
         cp ecsAmiCodeCommit/Config ecsAmiGithub/
         cd ecsAmiGithub
         git add Config
-        git commit -m "Add config"
+        git commit -m "Release ${date}"
         git remote add codecommit codecommit::us-west-2://amazon-ecs-ami-mirror
         git push codecommit main:shinkansen
   MetricPublish:

--- a/scripts/check-update-security.sh
+++ b/scripts/check-update-security.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -exo pipefail
 
 usage() {
     echo "Usage:"

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o pipefail
+set -exo pipefail
 
 usage() {
     echo "Usage:"


### PR DESCRIPTION
### Summary

- Changes to Github InitiateReleaseAction to create a PR instead of push directly to the repository.
- Also adds schedule for the action to run on.
- Also adds CODEOWNERS file to prevent non-aws-agent team members from triggering the github action. 
- Use the actions/checkout@v4.

### Implementation details
There is no longer a push in the github action to the aws/amazon-ecs-ami repository main branch. It now creates a branch for the release and pushes everything there. Then, if this is successful, it opens a pull request for the release. Instead of pushing to codecommit the latest main branch, it instead pushes the created branch. The reviewer then reviews both the internal and GH open PR at the same time.

### Testing
The following InitiateRelease was updated in my personal fork: https://github.com/hozkaya2000/amazon-ecs-ami/blob/main/.github/workflows/initiaterelease.yml 
(Note that it is the exact same workflow with only credentials and resources changed)

Successful run when there's no release needed: https://github.com/hozkaya2000/amazon-ecs-ami/actions/runs/8026018193/

Successful run when there's a release needed: https://github.com/hozkaya2000/amazon-ecs-ami/actions/runs/8026056794

New tests cover the changes: n/a 

### Description for the changelog
Enhanced AMI Release Action Updates

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
