### PR TITLE
Support AL2 kernel 5.10 GPU and INF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,14 @@ al2kernel5dot10: check-region init validate release-al2.auto.pkrvars.hcl
 al2kernel5dot10arm: check-region init validate release-al2.auto.pkrvars.hcl
 	./packer build -only="amazon-ebs.al2kernel5dot10arm" -var "region=${REGION}" .
 
+.PHONY: al2kernel5dot10gpu
+al2kernel5dot10gpu: check-region init validate release-al2.auto.pkrvars.hcl
+	./packer build -only="amazon-ebs.al2kernel5dot10gpu" -var "region=${REGION}" .
+
+.PHONY: al2kernel5dot10inf
+al2kernel5dot10inf: check-region init validate release-al2.auto.pkrvars.hcl
+	./packer build -only="amazon-ebs.al2kernel5dot10inf" -var "region=${REGION}" .
+
 .PHONY: al2023
 al2023: check-region init validate release-al2023.auto.pkrvars.hcl
 	./packer build -only="amazon-ebs.al2023" -var "region=${REGION}" .

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It will create a private AMI in whatever account you are running it in.
 
 1. Setup AWS cli credentials.
 2. Make the recipe that you want, REGION must be specified. Options are: al1, al2, al2arm, al2gpu, al2keplergpu, al2inf, 
-al2kernel5dot10, al2kernel5dot10arm, al2023, al2023arm, al2023neu.
+al2kernel5dot10, al2kernel5dot10arm, al2kernel5dot10gpu, al2kernel5dot10inf, al2023, al2023arm, al2023neu.
 ```
 REGION=us-west-2 make al2
 ```

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -40,7 +40,9 @@ build {
     "source.amazon-ebs.al2keplergpu",
     "source.amazon-ebs.al2inf",
     "source.amazon-ebs.al2kernel5dot10",
-    "source.amazon-ebs.al2kernel5dot10arm"
+    "source.amazon-ebs.al2kernel5dot10arm",
+    "source.amazon-ebs.al2kernel5dot10gpu",
+    "source.amazon-ebs.al2kernel5dot10inf"
   ]
 
   provisioner "file" {
@@ -174,12 +176,21 @@ build {
 
   provisioner "shell" {
     environment_vars = ["AMI_TYPE=${source.name}"]
-    script           = "scripts/enable-ecs-agent-inferentia-support.sh"
+    script           = "scripts/al2/install-kernel5dot10.sh"
+  }
+
+  ### If necessary, reboot worker instance to install kernel update for enable-ecs-agent-inferentia-support or
+  ### enable-ecs-agent-gpu-support scripts that factor in kernel version.
+  provisioner "shell" {
+    environment_vars  = ["AMI_TYPE=${source.name}"]
+    expect_disconnect = "true"
+    script            = "scripts/al2/reboot-for-kernel-upgrade.sh"
   }
 
   provisioner "shell" {
     environment_vars = ["AMI_TYPE=${source.name}"]
-    script           = "scripts/al2/install-kernel5dot10.sh"
+    pause_before     = "10s" # pause for starting the reboot
+    script           = "scripts/enable-ecs-agent-inferentia-support.sh"
   }
 
   provisioner "shell" {

--- a/al2kernel5dot10gpu.pkr.hcl
+++ b/al2kernel5dot10gpu.pkr.hcl
@@ -1,0 +1,33 @@
+locals {
+  ami_name_al2kernel5dot10gpu = "${var.ami_name_prefix_al2}-kernel-5.10-gpu-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
+}
+
+source "amazon-ebs" "al2kernel5dot10gpu" {
+  ami_name        = "${local.ami_name_al2kernel5dot10gpu}"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 x86_64 ECS HVM GP2"
+  instance_type   = var.gpu_instance_types[0]
+  launch_block_device_mappings {
+    volume_size           = var.block_device_size_gb
+    delete_on_termination = true
+    volume_type           = "gp2"
+    device_name           = "/dev/xvda"
+  }
+  region = var.region
+  source_ami_filter {
+    filters = {
+      name = "${var.source_ami_al2kernel5dot10}"
+    }
+    owners      = ["amazon"]
+    most_recent = true
+  }
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
+  tags = {
+    os_version          = "Amazon Linux 2"
+    source_image_name   = "{{ .SourceAMIName }}"
+    ecs_runtime_version = "Docker version ${var.docker_version}"
+    ecs_agent_version   = "${var.ecs_agent_version}"
+    ami_type            = "al2kernel5dot10gpu"
+    ami_version         = "2.0.${var.ami_version_al2}"
+  }
+}

--- a/al2kernel5dot10inf.pkr.hcl
+++ b/al2kernel5dot10inf.pkr.hcl
@@ -1,0 +1,34 @@
+locals {
+  ami_name_al2kernel5dot10inf = "${var.ami_name_prefix_al2}-kernel-5.10-inf-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
+}
+
+source "amazon-ebs" "al2kernel5dot10inf" {
+  ami_name        = "${local.ami_name_al2kernel5dot10inf}"
+  ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 x86_64 ECS HVM GP2"
+  instance_type   = var.inf_instance_types[0]
+  launch_block_device_mappings {
+    volume_size           = var.block_device_size_gb
+    delete_on_termination = true
+    volume_type           = "gp2"
+    device_name           = "/dev/xvda"
+  }
+  region = var.region
+  source_ami_filter {
+    filters = {
+      name = "${var.source_ami_al2kernel5dot10}"
+    }
+    owners      = ["amazon"]
+    most_recent = true
+  }
+  ssh_interface = "public_ip"
+  ssh_username  = "ec2-user"
+  tags = {
+    os_version          = "Amazon Linux 2"
+    source_image_name   = "{{ .SourceAMIName }}"
+    ecs_runtime_version = "Docker version ${var.docker_version}"
+    ecs_agent_version   = "${var.ecs_agent_version}"
+    ami_type            = "al2kernel5dot10inf"
+    ami_version         = "2.0.${var.ami_version_al2}"
+  }
+}
+

--- a/scripts/al2/install-kernel5dot10.sh
+++ b/scripts/al2/install-kernel5dot10.sh
@@ -4,7 +4,7 @@
 #   - Modify AL2 kernel 5.10 variables in generate-release-vars.sh to use SSM parameters of AL2 kernel 5.10 minimal AMIs
 set -ex
 
-if [[ $AMI_TYPE == "al2kernel5dot10" || $AMI_TYPE == "al2kernel5dot10arm" ]]; then
+if [[ $AMI_TYPE == "al2kernel5dot10"* ]]; then
     sudo amazon-linux-extras install -y kernel-5.10
     sudo rpm -e kernel-4.*
 fi

--- a/scripts/al2/reboot-for-kernel-upgrade.sh
+++ b/scripts/al2/reboot-for-kernel-upgrade.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# TO-DO: Disable/remove this script once Amazon Linux team has released AL2 kernel 5.10 minimal AMIs.
+set -ex
+
+if [[ $AMI_TYPE == "al2kernel5dot10gpu" || $AMI_TYPE == "al2kernel5dot10inf" ]]; then
+    sudo reboot
+fi

--- a/scripts/enable-ecs-agent-gpu-support.sh
+++ b/scripts/enable-ecs-agent-gpu-support.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 set -ex
 
-if [[ $AMI_TYPE != "al2gpu" && $AMI_TYPE != "al2keplergpu" ]]; then
+# Makes sure that a compatible version of gcc is used for compiling NVIDIA driver.
+set_compatible_gcc_version_for_nvidia_compile() {
+    # Currently a compatible version of gcc is assumed to be used by default, unless the AMI recipe uses kernel 5.10.
+    if [[ $AMI_TYPE == *"kernel5dot10gpu" ]]; then
+        # Explicitly use gcc10 since gcc version for compiling the NVIDIA driver must match gcc version with which the
+        # Linux kernel was compiled.
+        sudo sed -i "s/'make' -j2 module/& CC=\/usr\/bin\/gcc10-cc/" /usr/src/${MODULE_NAME}-${MODULE_VERSION}/dkms.conf
+    fi
+}
+
+if [[ $AMI_TYPE != "al2"*"gpu" ]]; then
     exit 0
 fi
 
@@ -22,6 +32,9 @@ gpgkey=https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/7fa
 enabled=1
 exclude=libglvnd-*
 EOF
+
+DKMS=/usr/sbin/dkms
+DKMS_ARCHIVE_DIR=/var/lib/dkms-archive
 
 # the amzn2-nvidia repo is temporary and only used for installing the system-release-nvidia package
 sudo mv $tmpfile /etc/yum.repos.d/amzn2-nvidia-tmp.repo
@@ -45,11 +58,9 @@ if [[ $AMI_TYPE != "al2keplergpu" && -z ${AIR_GAPPED} ]]; then
     sudo yum install -y nvidia-kmod-common-${NVIDIA_VERSION}
 
     # build nvidia-open kmod tar
-    DKMS=/usr/sbin/dkms
-    DKMS_ARCHIVE_DIR=/var/lib/dkms-archive
     MODULE_NAME="nvidia-open"
     MODULE_VERSION=$(${DKMS} status -m ${MODULE_NAME} | awk '{print $2}' | tr -d ',:')
-
+    set_compatible_gcc_version_for_nvidia_compile
     sudo ${DKMS} build -m "${MODULE_NAME}" -v "${MODULE_VERSION}"
     sudo ${DKMS} mktarball -m "${MODULE_NAME}" -v "${MODULE_VERSION}"
     sudo mkdir -p "${DKMS_ARCHIVE_DIR}/${MODULE_NAME}/"
@@ -135,6 +146,14 @@ else
 
     sudo yum install -y cuda-drivers \
         cuda
+fi
+
+if [[ $AMI_TYPE == *"kernel5dot10gpu" ]]; then
+    # rebuild module/update drivers using compatible gcc version (gcc10)
+    MODULE_NAME="nvidia"
+    MODULE_VERSION=$(${DKMS} status -m ${MODULE_NAME} | awk '{print $2}' | tr -d ',:')
+    set_compatible_gcc_version_for_nvidia_compile
+    sudo ${DKMS} install -m "${MODULE_NAME}" -v "${MODULE_VERSION}"
 fi
 
 # The Fabric Manager service needs to be started and enabled on EC2 P4d instances

--- a/scripts/enable-ecs-agent-inferentia-support.sh
+++ b/scripts/enable-ecs-agent-inferentia-support.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-if [[ $AMI_TYPE != "al2inf" && $AMI_TYPE != "al2023neu" ]]; then
+if [[ $AMI_TYPE != "al2"*"inf" && $AMI_TYPE != "al2023neu" ]]; then
     exit 0
 fi
 
@@ -32,7 +32,7 @@ sudo yum install -y aws-neuronx-oci-hook-2.*
 
 # Install oci-add-hooks
 # TODO: oci-add-hooks package has compatibility issue with AL2023 IMDSv2. Remove condition after root caused and resolved
-if [[ $AMI_TYPE == "al2inf" ]]; then
+if [[ $AMI_TYPE == "al2"*"inf" ]]; then
     sudo yum install -y oci-add-hooks
 fi
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add new GPU and INF packer recipes using AL2 kernel 5.10.

### Implementation details
<!-- How are the changes implemented? -->
- Create `al2kernel5dot10gpu.pkr.hcl` and `al2kernel5dot10inf.pkr.hcl`
- Modify `al2.pkr.hcl` build sources to include `al2kernel5dot10gpu` and `al2kernel5dot10inf`
- Add new targets `al2kernel5dot10gpu` and `al2kernel5dot10inf` to `Makefile` and `README.md`
- Run AL2 install kernel 5.10 script when `AMI_TYPE` starts with "al2kernel5dot10"
- Run enable GPU support script when `AMI_TYPE` starts with "al2" and ends with "gpu"
- Make sure the NVIDIA driver used is compiled with the appropriate GCC version (gcc10) for kernel 5.10 GPU AMI type
   - Ref: https://nvidia.custhelp.com/app/answers/detail/a_id/5323/~/known-issue%3A-nvidia-vgpu-software-graphics-driver-installation-fails-on-some 
- Run enable Inferentia support script when `AMI_TYPE` starts with "al2" and ends with "inf" (or is "al2023neu")
- Add a reboot after executing install kernel 5.10 script and make sure that enable GPU support script is executed after the reboot
   - Ref: https://github.com/aws/amazon-ecs-ami/blob/main/al2023.pkr.hcl#L144-L162 (this follows current behavior for ECS-Optimized AL2023 Neuron AMI variant)


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

✅ Successfully build AMIs using the new AMI recipes locally.
✅ Launch EC2 instances using the built AMIs.
✅ Confirm Linux kernel version 5.10 is enabled and running on the launched instances.
✅ Confirm kernel and kernel header packages installed in the RPM database are only for Linux kernel 5.10 on the launched instances.
✅ Run relevant GPU and INF functional tests against the built AMIs from manual testing steps above and ensure all tests pass.
✅ For the built GPU kernel 5.10 AMI, run testing steps from https://github.com/aws/amazon-ecs-ami/pull/163 against it and make sure they are successful. This is to ensure post-kepler NVIDIA open kernel module installation still behaves as expected.

<details>

<summary>Additional sanity checks</summary>
On EC2 instance launched using built GPU kernel 5.10 AMI:

```
$ dkms status
nvidia, 535.129.03, 5.10.209-198.858.amzn2.x86_64, x86_64: installed
```

```
$ nvidia-smi
Tue Feb 27 03:14:43 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.129.03             Driver Version: 535.129.03   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla T4                       On  | 00000000:00:1E.0 Off |                    0 |
| N/A   30C    P0              24W /  70W |      2MiB / 15360MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
```

On EC2 instance launched using built INF kernel 5.10 AMI:

```
$ dkms status
aws-neuronx, 2.15.9.0, 5.10.209-198.858.amzn2.x86_64, x86_64: installed
```

</details>


New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Support AL2 kernel 5.10 GPU and INF

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
