### PR TITLE
Fix diff calculation error out on github action

### DIFF
--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -23,7 +23,9 @@ fi
 
 cp release-$ami_type.auto.pkrvars.hcl release-$ami_type.old.hcl
 ./generate-release-vars.sh $ami_type
+set +e
 diff_val=$(diff <(grep -v ami_version release-$ami_type.old.hcl) <(grep -v ami_version release-$ami_type.auto.pkrvars.hcl))
+set -e
 # If no difference in dependencies, check for security update
 if [ -z "$diff_val" ]; then
     # al2023 version already generates a diff in dependency file if it has security updates, so no check necessary if al2023


### PR DESCRIPTION
### Summary
Fix premature exiting issue regarding InitiateRelease github action. 

### Implementation details
Add failure preventing code around "diff" command to prevent a non-zero exit code from being interpreted as a failure. 

### Testing
Tested previously on personal fork with test action. This file change being separate from the InitiateRelease action caused this change to be missed. 

New tests cover the changes: n/a

### Description for the changelog

N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
