### PR TITLE
Add AL2 GPU/INF kernel 5.10 AMIs to release notes

### DIFF
--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -16,7 +16,7 @@ Usage:
 
 Options:
 	--al2-gpu-nvidia-ver  (Optional) AL2 GPU NVIDIA version. If specified, then --al2-gpu-cuda-ver option is also required to be specified.
-	--al2-gpu-cuda-ver    (Optional) AL2 GPU CUDA version. If specified, then  --al2-gpu-nvidia optin is also required to be specified.
+	--al2-gpu-cuda-ver    (Optional) AL2 GPU CUDA version. If specified, then  --al2-gpu-nvidia-ver option is also required to be specified.
 	--al1-containerd-ver  (Optional) AL1 containerd version.
 	--al1-runc-ver        (Optional) AL1 runc version.
 	--exclude-ami         (Optional) comma separated list of AMI variants that are excluded in the release.
@@ -74,7 +74,7 @@ parse_args() {
 # Validates the options specified for the script.
 validate_args() {
     if [ -z "$AL2_GPU_CUDA_VERSION" ] || [ -z "$AL2_GPU_NVIDIA_VERSION" ]; then
-        if ! is_ami_excluded "al2gpu"; then
+        if ! { is_ami_excluded "al2gpu" && is_ami_excluded "al2kernel5dot10gpu"; }; then
             printf "Error: AL2 GPU CUDA version or AL2 GPU NVIDIA version is empty when releasing AL2 GPU\n\n"
             usage
             exit 1
@@ -178,7 +178,8 @@ https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#$ami_version
 
     # AL2
     if ! { is_ami_excluded "al2" && is_ami_excluded "al2arm" && is_ami_excluded "al2inf" && is_ami_excluded "al2gpu" &&
-        is_ami_excluded "al2kernel5dot10" && is_ami_excluded "al2kernel5dot10arm"; }; then
+        is_ami_excluded "al2kernel5dot10" && is_ami_excluded "al2kernel5dot10arm" &&
+        is_ami_excluded "al2kernel5dot10inf" && is_ami_excluded "al2kernel5dot10gpu"; }; then
         # Get AL2 AMI family details
         readonly containerd_version=$(cat $variablespkr | sed -n '/containerd_version"/,/}/p' | grep -w 'default' | cut -d '"' -f2)
         readonly runc_version=$(cat $variablespkr | sed -n '/runc_version"/,/}/p' | grep -w 'default' | cut -d '"' -f2)
@@ -211,14 +212,14 @@ https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#$ami_version
             add_ami_to_release_notes "#### ARM64 (Kernel 4.14)" "$ami_name_al2_arm" "$agent_version_al2_arm" "$docker_version_al2_arm" "$containerd_version" "$runc_version" "" "" "$source_ami_name_al2_arm" ""
         fi
 
-        # Include AL2 Neuron release notes if there was an al2inf release
+        # Include AL2 Neuron (Kernel 4.14) release notes if there was an al2inf release
         if ! is_ami_excluded "al2inf"; then
             # AL2 Neuron AMI details
             read ami_name_al2_inf agent_version_al2_inf docker_version_al2_inf source_ami_name_al2_inf <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/inf/recommended")
             add_ami_to_release_notes "#### Neuron (Kernel 4.14)" "$ami_name_al2_inf" "$agent_version_al2_inf" "$docker_version_al2_inf" "$containerd_version" "$runc_version" "" "" "$source_ami_name_al2_inf" ""
         fi
 
-        # Include AL2 GPU release notes if there was an al2gpu release
+        # Include AL2 GPU (Kernel 4.14) release notes if there was an al2gpu release
         if ! is_ami_excluded "al2gpu"; then
             # AL2 GPU AMI details
             read ami_name_al2_gpu agent_version_al2_gpu docker_version_al2_gpu source_ami_name_al2_gpu <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended")
@@ -237,6 +238,20 @@ https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#$ami_version
             # AL2 ARM64 (Kernel 5.10) AMI details
             read ami_name_al2_kernel_5_10_arm agent_version_al2_kernel_5_10_arm docker_version_al2_kernel_5_10_arm source_ami_name_al2_kernel_5_10_arm <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/kernel-5.10/arm64/recommended")
             add_ami_to_release_notes "#### ARM64 (Kernel 5.10)" "$ami_name_al2_kernel_5_10_arm" "$agent_version_al2_kernel_5_10_arm" "$docker_version_al2_kernel_5_10_arm" "$containerd_version" "$runc_version" "" "" "$source_ami_name_al2_kernel_5_10_arm" ""
+        fi
+
+        # Include AL2 Neuron (Kernel 5.10) release notes if there was an al2kernel5dot10inf release
+        if ! is_ami_excluded "al2kernel5dot10inf"; then
+            # AL2 Neuron (Kernel 5.10) AMI details
+            read ami_name_al2_kernel_5_10_inf agent_version_al2_kernel_5_10_inf docker_version_al2_kernel_5_10_inf source_ami_name_al2_kernel_5_10_inf <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/kernel-5.10/inf/recommended")
+            add_ami_to_release_notes "#### Neuron (Kernel 5.10)" "$ami_name_al2_kernel_5_10_inf" "$agent_version_al2_kernel_5_10_inf" "$docker_version_al2_kernel_5_10_inf" "$containerd_version" "$runc_version" "" "" "$source_ami_name_al2_kernel_5_10_inf" ""
+        fi
+
+        # Include AL2 GPU (Kernel 5.10) release notes if there was an al2kernel5dot10gpu release
+        if ! is_ami_excluded "al2kernel5dot10gpu"; then
+            # AL2 GPU (Kernel 5.10) AMI details
+            read ami_name_al2_kernel_5_10_gpu agent_version_al2_kernel_5_10_gpu docker_version_al2_kernel_5_10_gpu source_ami_name_al2_kernel_5_10_gpu <<<$(get_ami_details "/aws/service/ecs/optimized-ami/amazon-linux-2/kernel-5.10/gpu/recommended")
+            add_ami_to_release_notes "#### GPU (Kernel 5.10)" "$ami_name_al2_kernel_5_10_gpu" "$agent_version_al2_kernel_5_10_gpu" "$docker_version_al2_kernel_5_10_gpu" "$containerd_version" "$runc_version" "$AL2_GPU_NVIDIA_VERSION" "$AL2_GPU_CUDA_VERSION" "$source_ami_name_al2_kernel_5_10_gpu" ""
         fi
     fi
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add AL2 GPU Kernel 5.10 and AL2 Neuron (INF) Kernel 5.10 variants of the ECS-Optimized AMI to the generate release notes script.

**IMPORTANT**: The changes in this pull request are dependent on SSM parameters being published for these new variants of the ECS-Optimized AMI. Thus, this pull request will not be merged until ECS Agent team is ready to publish these new AMI variants (and their SSM parameters) for the first time.

### Implementation details
<!-- How are the changes implemented? -->
See "Summary" section above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Manually temporarily replaced the currently unavailable GPU/INF kernel 5.10 SSM parameters (on L246 and L253) with the GPU/INF (kernel 4.14) SSM parameters. Afterwards, tested generating release notes for `20240305` release using `./generate-release-notes.sh --al2-gpu-nvidia-ver 535.161.07 --al2-gpu-cuda-ver 12.2.2 --al1-containerd-ver 1.4.13 --al1-runc-ver 1.1.11` command and compared the generated release notes against [the expected release notes](https://github.com/aws/amazon-ecs-ami/releases/tag/20240305) using `diff`. The only difference observed is that entries for AL2 GPU Kernel 5.10 and AL2 Neuron (INF) Kernel 5.10 variants of the ECS-Optimized AMI now show up in the generated output (as expected).

<details>

<summary>Generated output</summary>

```
### Source AMI release notes
---
* [Amazon Linux 2023 release notes](https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html)
* [Amazon Linux 2 release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)
* [Amazon Linux release notes](https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes)

### Changelog
---
https://github.com/aws/amazon-ecs-ami/blob/main/CHANGELOG.md#20240305

### Amazon ECS-optimized Amazon Linux 2023 AMI
---
#### AMD64
- AMI name: al2023-ami-ecs-hvm-2023.0.20240305-kernel-6.1-x86_64
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- Source AMI name: al2023-ami-minimal-2023.3.20240219.0-kernel-6.1-x86_64
- Distribution al2023 release: 2023.3.20240219

#### ARM64
- AMI name: al2023-ami-ecs-hvm-2023.0.20240305-kernel-6.1-arm64
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- Source AMI name: al2023-ami-minimal-2023.3.20240219.0-kernel-6.1-arm64
- Distribution al2023 release: 2023.3.20240219

#### Neuron
- AMI name: al2023-ami-ecs-neuron-hvm-2023.0.20240305-kernel-6.1-x86_64
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- Source AMI name: al2023-ami-minimal-2023.3.20240219.0-kernel-6.1-x86_64
- Distribution al2023 release: 2023.3.20240219

### Amazon ECS-optimized Amazon Linux 2 AMI
---
#### AMD64 (Kernel 4.14)
- AMI name: amzn2-ami-ecs-hvm-2.0.20240305-x86_64-ebs
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20240223.0-x86_64-ebs

#### ARM64 (Kernel 4.14)
- AMI name: amzn2-ami-ecs-hvm-2.0.20240305-arm64-ebs
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20240223.0-arm64-ebs

#### Neuron (Kernel 4.14)
- AMI name: amzn2-ami-ecs-inf-hvm-2.0.20240305-x86_64-ebs
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20240223.0-x86_64-ebs

#### GPU (Kernel 4.14)
- AMI name: amzn2-ami-ecs-gpu-hvm-2.0.20240305-x86_64-ebs
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- NVIDIA driver version: 535.161.07
- CUDA version: 12.2.2
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20240223.0-x86_64-ebs

#### AMD64 (Kernel 5.10)
- AMI name: amzn2-ami-ecs-kernel-5.10-hvm-2.0.20240305-x86_64-ebs
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20240223.0-x86_64-ebs

#### ARM64 (Kernel 5.10)
- AMI name: amzn2-ami-ecs-kernel-5.10-hvm-2.0.20240305-arm64-ebs
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20240223.0-arm64-ebs

#### Neuron (Kernel 5.10)
- AMI name: amzn2-ami-ecs-inf-hvm-2.0.20240305-x86_64-ebs
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20240223.0-x86_64-ebs

#### GPU (Kernel 5.10)
- AMI name: amzn2-ami-ecs-gpu-hvm-2.0.20240305-x86_64-ebs
- ECS Agent version: [1.82.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.82.0)
- Docker version: 20.10.25
- Containerd version: 1.7.11
- Runc version: 1.1.11
- NVIDIA driver version: 535.161.07
- CUDA version: 12.2.2
- Source AMI name: amzn2-ami-minimal-hvm-2.0.20240223.0-x86_64-ebs

### Amazon ECS-optimized Amazon Linux AMI
---
The Amazon ECS-optimized Amazon Linux AMI is deprecated as of April 15, 2021. After that date, Amazon ECS will continue providing critical and important security updates for the AMI but will not add support for new features.

- AMI name: amzn-ami-2018.03.20240305-amazon-ecs-optimized
- ECS Agent version: [1.51.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.51.0)
- Docker version: 20.10.13
- Containerd version: 1.4.13
- Runc version: 1.1.11
- Source AMI name: amzn-ami-minimal-hvm-2018.03.0.20231218.0-x86_64-ebs
```

</details>

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add AL2 GPU/INF kernel 5.10 AMIs to release notes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
