### PR TITLE
Setup ECS config directory if not present

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -90,6 +90,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/setup-ecs-config-dir.sh"
+  }
+
+  provisioner "shell" {
     inline_shebang = "/bin/sh -ex"
     inline = [
       "sudo yum install -y docker-${var.docker_version_al1} ecs-init-${var.ecs_version_al1} ${local.packages_al1}"

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -104,6 +104,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/setup-ecs-config-dir.sh"
+  }
+
+  provisioner "shell" {
     script = "scripts/install-docker.sh"
     environment_vars = [
       "DOCKER_VERSION=${var.docker_version}",

--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -84,6 +84,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/setup-ecs-config-dir.sh"
+  }
+
+  provisioner "shell" {
     script = "scripts/install-docker.sh"
     environment_vars = [
       "DOCKER_VERSION=${var.docker_version_al2023}",

--- a/scripts/setup-ecs-config-dir.sh
+++ b/scripts/setup-ecs-config-dir.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+sudo mkdir -p "/etc/ecs"
+
+if [ ! -f "/etc/ecs/ecs.config" ]; then
+    sudo touch /etc/ecs/ecs.config
+fi
+
+if [ ! -f "/etc/ecs/ecs.config.json" ]; then
+    sudo touch /etc/ecs/ecs.config.json
+fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Set up the ECS config directory at AMI build time if it is not already present.

### Implementation details
<!-- How are the changes implemented? -->
- Create script `scripts/setup-ecs-config-dir.sh`
- Call this script for all AL AMI families (i.e., AL2023, AL2, AL1) as all can benefit from this change

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Build AL2023, AL2, and AL1 AMD64 custom AMIs with these changes and run functional tests against them.

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Setup ECS config directory if not present 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
