### PR TITLE
Add include_deprecated=true to all recipes

### DIFF
--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2" {
     filters = {
       name = "${var.source_ami_al2}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2023" {
     filters = {
       name = "${var.source_ami_al2023}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2023arm.pkr.hcl
+++ b/al2023arm.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2023arm" {
     filters = {
       name = "${var.source_ami_al2023arm}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2023neu.pkr.hcl
+++ b/al2023neu.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2023neu" {
     filters = {
       name = "${var.source_ami_al2023}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2arm" {
     filters = {
       name = "${var.source_ami_al2arm}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2gpu" {
     filters = {
       name = "${var.source_ami_al2}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2inf" {
     filters = {
       name = "${var.source_ami_al2}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2keplergpu.pkr.hcl
+++ b/al2keplergpu.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2keplergpu" {
     filters = {
       name = "${var.source_ami_al2}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2kernel5dot10.pkr.hcl
+++ b/al2kernel5dot10.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2kernel5dot10" {
     filters = {
       name = "${var.source_ami_al2kernel5dot10}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2kernel5dot10arm.pkr.hcl
+++ b/al2kernel5dot10arm.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2kernel5dot10arm" {
     filters = {
       name = "${var.source_ami_al2kernel5dot10arm}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2kernel5dot10gpu.pkr.hcl
+++ b/al2kernel5dot10gpu.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2kernel5dot10gpu" {
     filters = {
       name = "${var.source_ami_al2kernel5dot10}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"

--- a/al2kernel5dot10inf.pkr.hcl
+++ b/al2kernel5dot10inf.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "al2kernel5dot10inf" {
     filters = {
       name = "${var.source_ami_al2kernel5dot10}"
     }
-    owners      = ["amazon"]
-    most_recent = true
+    owners             = ["amazon"]
+    most_recent        = true
+    include_deprecated = true
   }
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds `include_deprecated=true` to the AMI recipes.

During an AMI build, Packer uses the name of the Amazon Linux source AMI we defined in `release-*.auto.pkvars.hcl`. It uses the most recent AMI that has the given name. In AL1 recipe, we added `included_deprecated=true` since the AL1 base AMIs are deprecated.

This PR adds the same flag to all other recipes, so that whenever the base AMI is deprecated, Packer is still able to find and use it. It doesn't change anything functionally, but is more of a safety net - for example, when Amazon Linux deprecates the AL2 base AMI in the future, ECS AMI builds will not be impacted.

### Implementation details
<!-- How are the changes implemented? -->
Updated all AMI recipes with `include_deprecated=true` like it is in the [AL1 recipe](https://github.com/aws/amazon-ecs-ami/blob/291de54065ebbda8b6fca594d899ea49afe09521/al1.pkr.hcl#L28) today.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: Add `include_deprecated=true` to all AMI recipes.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
