### PR TITLE
Disable security updates at launch for ECS-optimized AL2 AMIs

### DIFF
--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -85,6 +85,33 @@ build {
     ]
   }
 
+  provisioner "file" {
+    source      = "files/69-available-updates-begin.sh.amzn2"
+    destination = "/tmp/69-available-updates-begin"
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/sh -ex"
+    inline = [
+      "sudo mv /tmp/69-available-updates-begin /etc/update-motd.d/69-available-updates-begin",
+      "sudo chmod 755 /etc/update-motd.d/69-available-updates-begin"
+    ]
+  }
+
+
+  provisioner "file" {
+    source      = "files/71-available-updates-finish.sh.amzn2"
+    destination = "/tmp/71-available-updates-finish"
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/sh -ex"
+    inline = [
+      "sudo mv /tmp/71-available-updates-finish /etc/update-motd.d/71-available-updates-finish",
+      "sudo chmod 755 /etc/update-motd.d/71-available-updates-finish"
+    ]
+  }
+
   provisioner "shell" {
     inline_shebang = "/bin/sh -ex"
     inline = [

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -1,5 +1,11 @@
 locals {
   ami_name_al2 = "${var.ami_name_prefix_al2}-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
+  motd_files = [
+    "29-ecs-banner-begin",
+    "31-ecs-banner-finish",
+    "69-available-updates-begin",
+    "71-available-updates-finish"
+  ]
 }
 
 source "amazon-ebs" "al2" {
@@ -59,57 +65,25 @@ build {
     ]
   }
 
-  provisioner "file" {
-    source      = "files/29-ecs-banner-begin.sh.amzn2"
-    destination = "/tmp/29-ecs-banner-begin"
+  dynamic "provisioner" {
+    for_each = local.motd_files
+    labels   = ["file"]
+    content {
+      source      = "files/${provisioner.value}.sh.amzn2"
+      destination = "/tmp/${provisioner.value}"
+    }
   }
 
-  provisioner "shell" {
-    inline_shebang = "/bin/sh -ex"
-    inline = [
-      "sudo mv /tmp/29-ecs-banner-begin /etc/update-motd.d/29-ecs-banner-begin",
-      "sudo chmod 755 /etc/update-motd.d/29-ecs-banner-begin"
-    ]
-  }
-
-  provisioner "file" {
-    source      = "files/31-ecs-banner-finish.sh.amzn2"
-    destination = "/tmp/31-ecs-banner-finish"
-  }
-
-  provisioner "shell" {
-    inline_shebang = "/bin/sh -ex"
-    inline = [
-      "sudo mv /tmp/31-ecs-banner-finish /etc/update-motd.d/31-ecs-banner-finish",
-      "sudo chmod 755 /etc/update-motd.d/31-ecs-banner-finish"
-    ]
-  }
-
-  provisioner "file" {
-    source      = "files/69-available-updates-begin.sh.amzn2"
-    destination = "/tmp/69-available-updates-begin"
-  }
-
-  provisioner "shell" {
-    inline_shebang = "/bin/sh -ex"
-    inline = [
-      "sudo mv /tmp/69-available-updates-begin /etc/update-motd.d/69-available-updates-begin",
-      "sudo chmod 755 /etc/update-motd.d/69-available-updates-begin"
-    ]
-  }
-
-
-  provisioner "file" {
-    source      = "files/71-available-updates-finish.sh.amzn2"
-    destination = "/tmp/71-available-updates-finish"
-  }
-
-  provisioner "shell" {
-    inline_shebang = "/bin/sh -ex"
-    inline = [
-      "sudo mv /tmp/71-available-updates-finish /etc/update-motd.d/71-available-updates-finish",
-      "sudo chmod 755 /etc/update-motd.d/71-available-updates-finish"
-    ]
+  dynamic "provisioner" {
+    for_each = local.motd_files
+    labels   = ["shell"]
+    content {
+      inline_shebang = "/bin/sh -ex"
+      inline = [
+        "sudo mv /tmp/${provisioner.value} /etc/update-motd.d/${provisioner.value}",
+        "sudo chmod 755 /etc/update-motd.d/${provisioner.value}"
+      ]
+    }
   }
 
   provisioner "shell" {

--- a/files/69-available-updates-begin.sh.amzn2
+++ b/files/69-available-updates-begin.sh.amzn2
@@ -1,0 +1,38 @@
+#!/usr/bin/bash
+
+# Copyright (C) 2024 Amazon.com, Inc. or its affiliates.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+package_updates=$(LANG=C timeout 30s /usr/bin/yum \
+  --debuglevel 2 \
+  --security check-update 2>/dev/null \
+  | grep -P '(?<! 0 packages) available$')
+
+if [ -n "$package_updates" ]; then
+  echo "$package_updates
+Update to the latest ECS-Optimized AMI for all updates, including security"
+
+  security_updates=$(grep -oP '(\d+)(?=.* security)' <<< "$package_updates")
+
+  if [ ${security_updates:=0} -ne 0 ]; then
+    echo 'Run "sudo yum update --security" to apply security updates in place'
+  fi
+
+  echo 'Run "sudo yum update" to apply all updates in place'
+fi
+
+# Disable 70-available-updates during update-motd, reverted with
+# 71-available-updates-finish.
+chmod -x /etc/update-motd.d/70-available-updates

--- a/files/69-available-updates-begin.sh.amzn2
+++ b/files/69-available-updates-begin.sh.amzn2
@@ -33,6 +33,12 @@ Update to the latest ECS-Optimized AMI for all updates, including security"
   echo 'Run "sudo yum update" to apply all updates in place'
 fi
 
-# Disable 70-available-updates during update-motd, reverted with
-# 71-available-updates-finish.
+# The order in which update-motd runs the scripts is
+# 1. 69-available-updates-begin
+# 2. 70-available-updates
+# 3. 71-available-updates-finish
+#
+# 70-available-updates is inherited from AL2. It is disabled here but re-enabled in
+# 71-available-updates-finish so that the custom ECS message shows but the AL2
+# message does not.
 chmod -x /etc/update-motd.d/70-available-updates

--- a/files/69-available-updates-begin.sh.amzn2
+++ b/files/69-available-updates-begin.sh.amzn2
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations under the
 # License.
 
+# package_updates is a summary of the number of updates available.
+# It is copied from 70-available-updates, which is inherited from AL2.
 package_updates=$(LANG=C timeout 30s /usr/bin/yum \
   --debuglevel 2 \
   --security check-update 2>/dev/null \

--- a/files/71-available-updates-finish.sh.amzn2
+++ b/files/71-available-updates-finish.sh.amzn2
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+# Copyright (C) 2024 Amazon.com, Inc. or its affiliates.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+# Re-enable 70-available-updates to return to packaged defaults
+# after being disabled by 69-available-updates-begin.
+chmod +x /etc/update-motd.d/70-available-updates

--- a/files/90_ecs.cfg.amzn2
+++ b/files/90_ecs.cfg.amzn2
@@ -1,4 +1,6 @@
 #cloud-config
+repo_upgrade: none
+
 system_info:
   default_user:
     groups: [ "wheel", "docker" ]


### PR DESCRIPTION
### Summary
By default, ECS-optimized AL2 AMIs install critical and important security updates at launch. This behavior is inherited from AL2.

After June 12, newly released ECS-optimized AL2 AMIs will no longer install security updates at launch.
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#ecs-optimized-AMI-security-changes

This PR disables security updates at launch for ECS-optimized AL2 AMIs and updates the MOTD to notify about the security changes.

### Implementation details
#### Cloud config changes
The cloud config inherited from AL2 includes the line `repo_upgrade: security`. This causes security updates to be installed at launch.
Override this setting by adding `repo_upgrade: none` to the [ECS-optimized AL2 cloud config](https://github.com/aws/amazon-ecs-ami/blob/main/files/90_ecs.cfg.amzn2). This will disable all updates at launch.

https://docs.aws.amazon.com/linux/al2/ug/ec2.html#security-updates

#### MOTD changes
**Security and non-security updates available**
Before
<img width="528" alt="current_motd_updates" src="https://github.com/aws/amazon-ecs-ami/assets/1168893/660123e7-647c-4450-b430-c9a4355d9f1f">
After
<img width="602" alt="Screenshot 2024-06-07 at 12 57 10 PM" src="https://github.com/aws/amazon-ecs-ami/assets/1168893/9877356e-fa39-4420-8b67-6f3e4700e543">

**Non-security updates available**
Before
<img width="521" alt="current_motd_no_security_updates" src="https://github.com/aws/amazon-ecs-ami/assets/1168893/413a6788-51d4-4c4f-8809-2007d8823b66">
After
<img width="601" alt="Screenshot 2024-06-07 at 12 58 31 PM" src="https://github.com/aws/amazon-ecs-ami/assets/1168893/439a9877-6622-4b5b-ba98-1f982ebb78c1">

**No updates available**
Before
<img width="524" alt="current_motd_no_updates" src="https://github.com/aws/amazon-ecs-ami/assets/1168893/aee0e37b-ebc0-4a84-a40a-fd0babe8df26">
After
<img width="522" alt="Screenshot 2024-06-07 at 12 59 34 PM" src="https://github.com/aws/amazon-ecs-ami/assets/1168893/cd516f0a-294a-4dc5-84d2-05d15d3b8f5c">

### Testing
#### Built an AMI
1. Overrode [source_ami_al2](https://github.com/aws/amazon-ecs-ami/blob/main/release-al2.auto.pkrvars.hcl#L8) with an AL2 AMI from 2023.
2. Ran `make al2`.

#### Testing `yum update --security`
1. Launched an EC2 instance with the new AMI.
2. `ssh`'d into the instance and verified that the MOTD showed there were security and non-security updates available.
3. Ran `sudo yum update -y --security` and logged out.
4. `ssh`'d into the instance and verified that the MOTD showed there were non-security updates available.
5. Ran `sudo yum update -y` and logged out.
6. `ssh`'d into the instance and verified that the MOTD did not mention anything about updates.
7. Checked cloud-init logs and verified that cloud-init never ran any YUM commands.

#### Testing cloud config override from user data
1. Launched an EC2 instance with the new AMI and passed the following as user data:
```
#cloud-config
repo_upgrade: security
```
2. `ssh`'d into the instance and verified that security updates shown in the MOTD were neither critical nor important, or in the repo exclusion list inherited from AL2.
```
yum check-update --security --sec-severity=critical --sec-severity=important
```
3. Checked cloud-init logs and verified that cloud-init ran
```
yum -t -y --exclude=kernel --exclude=nvidia* --exclude=cuda --security --sec-severity=critical --sec-severity=important upgrade
```
New tests cover the changes: no

### Description for the changelog
Disable security updates at launch for ECS-optimized AL2 AMIs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
