### PR TITLE
Remove air-gapped region check in install-docker script

### DIFF
--- a/scripts/install-docker.sh
+++ b/scripts/install-docker.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-if [ -n "$AIR_GAPPED" ]; then
-    echo "Air-gapped region, assuming docker and dependencies will be in additional-packages/ directory"
-    exit 0
-fi
-
 if command -v amazon-linux-extras; then
     # enable docker "extras" repo when available
     sudo amazon-linux-extras enable docker


### PR DESCRIPTION
### Summary
Update to internal release process requires us to not skip the install docker step in this script. 

### Implementation details
Remove no longer necessary air-gapped region control flow. 

### Testing
Will be tested internally. 

### Description for the changelog
Update install-docker script

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
