### PR TITLE
fix(cleanup): remove unnecessary cleanup

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -85,24 +85,6 @@ INSTANCE_LOG_FILES=(
 echo "Cleaning up instance log files"
 cleanup "${INSTANCE_LOG_FILES[@]}"
 
-echo "Cleaning TOE files"
-if [[ $(sudo find {{workingDirectory}}/TOE_* -type f | sudo wc -l) -gt 0 ]]; then
-    echo "Deleting files within {{workingDirectory}}/TOE_*"
-    sudo find {{workingDirectory}}/TOE_* -type f -exec shred -zuf {} \;
-fi
-if [[ $(sudo find {{workingDirectory}}/TOE_* -type f | sudo wc -l) -gt 0 ]]; then
-    echo "Failed to delete {{workingDirectory}}/TOE_*"
-    exit 1
-fi
-if [[ $(sudo find {{workingDirectory}}/TOE_* -type d | sudo wc -l) -gt 0 ]]; then
-    echo "Deleting {{workingDirectory}}/TOE_*"
-    sudo rm -rf {{workingDirectory}}/TOE_*
-fi
-if [[ $(sudo find {{workingDirectory}}/TOE_* -type d | sudo wc -l) -gt 0 ]]; then
-    echo "Failed to delete {{workingDirectory}}/TOE_*"
-    exit 1
-fi
-
 echo "Cleaning up ssm log files"
 if sudo test -d "/var/log/amazon/ssm"; then
     echo "Deleting /var/log/amazon/ssm/*"


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
These lines don't actually do anything because there is no `{{workingDirectory}}` set here

### Implementation details
Because these lines will never evaluate to true they can just be removed

### Testing

I built the image and  saw in the logs `{{workingDirectory}}/TOE_*` not found. So there is nothing  being inserted in there and the code will never resolve to anything

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
ENHANCEMENT - Remove unnecessary cleanup code that will never execute

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
