### PR TITLE
Change cron schedule of github actions

### DIFF
--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -3,7 +3,7 @@ name: InitiateRelease
 on: 
   workflow_dispatch:
   schedule: 
-    - cron: 0 18 * * 2
+    - cron: 0 18 * * 1-5
 
 jobs:
   GenerateConfig:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* Change the cron schedule of github actions to run at 6PM UTC from Mon - Fri instead of running only on Tuesdays at 6PM UTC

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
* Verified cron expression using https://crontab.guru/#0_18_*_*_1-5
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
