### PR TITLE
install oci-add-hooks on al2023 neuron ecs ami

### DIFF
--- a/scripts/enable-ecs-agent-inferentia-support.sh
+++ b/scripts/enable-ecs-agent-inferentia-support.sh
@@ -31,10 +31,7 @@ sudo yum install -y aws-neuronx-dkms-2.*
 sudo yum install -y aws-neuronx-oci-hook-2.*
 
 # Install oci-add-hooks
-# TODO: oci-add-hooks package has compatibility issue with AL2023 IMDSv2. Remove condition after root caused and resolved
-if [[ $AMI_TYPE == "al2"*"inf" ]]; then
-    sudo yum install -y oci-add-hooks
-fi
+sudo yum install -y oci-add-hooks
 
 # Install Neuron Tools
 sudo yum install -y aws-neuronx-tools


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds oci-add-hooks package to the ECS AL2023 Neuron AMI. We install this package on the AL2 (and AL2 Kernel 5.10) INF AMIs today.

### Implementation details
<!-- How are the changes implemented? -->

- `scripts/enable-ecs-agent-inferentia-support.sh`: Removed the condition that skips installation on anything other than the AL2 (and AL2 Kernel 5.10) INF AMIs. Only the AL2 (and AL2 Kernel 5.10) INF and AL2023 NEU ECS AMI recipes consume this code, so it is safe to remove the condition completely.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

- Built a test AMI and ran our agent and AMI functional tests against it. They passed.
- Follow the docker runtime setup for OCI neuron as described in this [AWS neuron tutorial](https://awsdocs-neuron.readthedocs-hosted.com/en/v2.18.2/containers/tutorials/tutorial-oci-hook.html#for-docker-runtime-setup-docker-to-use-oci-neuron-oci-runtime).
  - Confirmed that the docker daemon is able to configure the oci-neuron runtime correctly on the test AMI, by inspecting docker daemon logs.
  - Also compared it against the latest available ECS AL2023 Neuron AMI where the daemon runs into an error due to the missing `oci-add-hooks` package.
- Build a pytorch neuron container image and run a container with a neuron device configured, as described in [this  tutorial](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/tutorials/build-run-neuron-container.html).
   - The docker container runs successfully on my instance using the test AMI.
```
docker run -it --name pt17 --device=/dev/neuron0 neuron-container:pytorch neuron-ls
instance-type: inf1.xlarge
instance-id: redacted
+--------+--------+--------+---------+
| NEURON | NEURON | NEURON |   PCI   |
| DEVICE | CORES  | MEMORY |   BDF   |
+--------+--------+--------+---------+
| 0      | 4      | 8 GB   | 00:1f.0 |
```
  
   - Whereas, the same setup fails on the latest available ECS AL2023 Neuron AMI.

New tests cover the changes: <!-- yes|no --> N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: add oci-add-hooks package to the ECS AL2023 Neuron AMI.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
