### PR TITLE
adding a sleep in our release GH actions

### DIFF
--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -88,6 +88,9 @@ jobs:
     - name: Delete shinkansen branch on codecommit repository
       run: |
         aws codecommit delete-branch --repository-name amazon-ecs-ami-mirror --branch-name shinkansen
+    - name: Sleeping for 30 seconds after CodeCommit branch deletion and before recreating it
+      run: |
+        sleep 30
     - name: Configure prereqs
       run: |
         git config --global user.name "Github Action"

--- a/.github/workflows/manualtrigger.yml
+++ b/.github/workflows/manualtrigger.yml
@@ -19,6 +19,9 @@ jobs:
     - name: Delete shinkansen branch on codecommit repository
       run: |
         aws codecommit delete-branch --repository-name amazon-ecs-ami-mirror --branch-name shinkansen
+    - name: Sleeping for 30 seconds after CodeCommit branch deletion and before recreating it
+      run: |
+        sleep 30
     - name: Configure prereqs
       run: |
         git config --global user.name "Github Action"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds a sleep (30 seconds) in our release GH actions.

### Implementation details
<!-- How are the changes implemented? -->

We do 2 things in our GH action,
1. Delete a branch from our CodeCommit repository.
2. Recreate the branch by pushing the latest GitHub source code.

We need to wait a bit between the two steps above, so that our internal replication process has enough time to recognize these as 2 distinct steps and prevent a race condition.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
