### PR TITLE
Installing iproute-tc package within AMI recipes

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -9,8 +9,8 @@ packer {
 
 locals {
   packages_al1    = "amazon-efs-utils ec2-net-utils acpid irqbalance numactl rng-tools docker-storage-setup"
-  packages_al2    = "amazon-efs-utils ec2-net-utils acpid amazon-ssm-agent yum-plugin-upgrade-helper"
-  packages_al2023 = "amazon-efs-utils amazon-ssm-agent amazon-ec2-net-utils acpid"
+  packages_al2    = "amazon-efs-utils ec2-net-utils acpid amazon-ssm-agent yum-plugin-upgrade-helper iproute-tc"
+  packages_al2023 = "amazon-efs-utils amazon-ssm-agent amazon-ec2-net-utils acpid iproute-tc"
 }
 
 variable "ami_name_prefix_al1" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will add a new package (`iproute`) to be pre-installed within our ECS-Optimized AMIs so that the necessary utility tools will be added/bind mounted to the ECS Agent container.

### Implementation details
* Added `iproute-tc` to the list of packages to be installed via `yum` and `dnf` respectively for AL2 and AL2023 AMIs


Regarding the host bind mounts of agent, it seems like we're already including all of the known host directories of where `tc` utility tool will be located in
```
"HostConfig": {
            "Binds": [
                "/var/run:/var/run",
                "/var/log/ecs:/log",
                "/var/lib/ecs/data:/data",
                "/etc/ecs:/etc/ecs",
                "/var/cache/ecs:/var/cache/ecs",
                "/sys/fs/cgroup:/sys/fs/cgroup",
                "/var/lib/ecs:/var/lib/ecs",
                "/var/log/ecs/exec:/log/exec",
                "/etc/pki:/etc/pki:ro",
                "/run/docker/plugins:/run/docker/plugins:ro",
                "/etc/docker/plugins:/etc/docker/plugins:ro",
                "/usr/lib/docker/plugins:/usr/lib/docker/plugins:ro",
                "/var/lib/ecs/deps:/managed-agents:ro",
                "/var/lib/ecs/deps/execute-command/config:/managed-agents/execute-command/config",
                "/proc:/host/proc:ro",
                "/usr/lib:/usr/lib:ro",
                "/lib:/lib:ro",
                "/usr/lib64:/usr/lib64:ro",
                "/lib64:/lib64:ro",
                "/sbin:/host/sbin:ro",
                "/etc/alternatives:/etc/alternatives:ro",
                "/usr/sbin:/usr/sbin:ro",
                "/usr/bin/lsblk:/usr/bin/lsblk"
            ]
```

Location of where `tc` will be located in by platform types:
|Platform| Location|
|---------|---------|
|ubuntu 24| /usr/sbin/tc|
|ubuntu 22|/usr/sbin/tc|
|ubuntu 20 minimal|/usr/sbin/tc|
|ubuntu 20|/usr/sbin/tc|
|ubuntu 18|/sbin/tc|
|CentOS 7|/usr/sbin/tc|
|CentOS 8|/usr/sbin/tc|
|CentOS 9|/usr/sbin/tc|
|Debian 10|/usr/sbin/tc|
|Debian 11|/usr/sbin/tc|
|Debian 12|/usr/sbin/tc|
|SUSE 15|/usr/sbin/tc|
|AL2|/usr/sbin/tc|
|AL2023|/usr/sbin/tc|

### Testing

Locally built AL2:
```
amazon-ebs.al2: Installed:
    amazon-ebs.al2:   acpid.x86_64 0:2.0.19-9.amzn2.0.1
    amazon-ebs.al2:   amazon-efs-utils.x86_64 0:2.0.4-1.amzn2
    amazon-ebs.al2:   amazon-ssm-agent.x86_64 0:3.3.380.0-1.amzn2
    amazon-ebs.al2:   ec2-net-utils.noarch 0:1.7.3-1.amzn2
    amazon-ebs.al2:   iproute-tc.x86_64 0:5.10.0-2.amzn2.0.3
    amazon-ebs.al2:   yum-plugin-upgrade-helper.noarch 0:1.1.31-46.amzn2.0.1

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2: AMIs were created:
us-west-2: ami-058a10229f03fcd54

--> amazon-ebs.al2: AMIs were created:
us-west-2: ami-058a10229f03fcd54
```

Locally built AL2 ARM:
```
amazon-ebs.al2arm: Installed:
    amazon-ebs.al2arm:   acpid.aarch64 0:2.0.19-9.amzn2.0.1
    amazon-ebs.al2arm:   amazon-efs-utils.aarch64 0:2.0.4-1.amzn2
    amazon-ebs.al2arm:   amazon-ssm-agent.aarch64 0:3.3.380.0-1.amzn2
    amazon-ebs.al2arm:   ec2-net-utils.noarch 0:1.7.3-1.amzn2
    amazon-ebs.al2arm:   iproute-tc.aarch64 0:5.10.0-2.amzn2.0.3
    amazon-ebs.al2arm:   yum-plugin-upgrade-helper.noarch 0:1.1.31-46.amzn2.0.1

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2arm: AMIs were created:
us-west-2: ami-0c056b000ee43f688

--> amazon-ebs.al2arm: AMIs were created:
us-west-2: ami-0c056b000ee43f688
```

Locally built AL2 GPU:
```
amazon-ebs.al2gpu: Installed:
    amazon-ebs.al2gpu:   acpid.x86_64 0:2.0.19-9.amzn2.0.1
    amazon-ebs.al2gpu:   amazon-efs-utils.x86_64 0:2.0.4-1.amzn2
    amazon-ebs.al2gpu:   amazon-ssm-agent.x86_64 0:3.3.380.0-1.amzn2
    amazon-ebs.al2gpu:   ec2-net-utils.noarch 0:1.7.3-1.amzn2
    amazon-ebs.al2gpu:   iproute-tc.x86_64 0:5.10.0-2.amzn2.0.3
    amazon-ebs.al2gpu:   yum-plugin-upgrade-helper.noarch 0:1.1.31-46.amzn2.0.1

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2gpu: AMIs were created:
us-west-2: ami-0ed7aaddf86d3f2ed

--> amazon-ebs.al2gpu: AMIs were created:
us-west-2: ami-0ed7aaddf86d3f2ed
```

Locally built AL2023:
```
amazon-ebs.al2023: Installed:
    amazon-ebs.al2023:   acpid-2.0.32-4.amzn2023.0.2.x86_64
    amazon-ebs.al2023:   amazon-efs-utils-2.0.4-1.amzn2023.x86_64
    amazon-ebs.al2023:   amazon-ssm-agent-3.3.380.0-1.amzn2023.x86_64
    amazon-ebs.al2023:   gssproxy-0.8.4-2.amzn2023.0.3.x86_64
    amazon-ebs.al2023:   iproute-tc-5.10.0-2.amzn2023.0.5.x86_64

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2023: AMIs were created:
us-west-2: ami-0d413e960d9190cb5

--> amazon-ebs.al2023: AMIs were created:
us-west-2: ami-0d413e960d9190cb5
```




### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
