### PR TITLE
pin the aws-neuronx-dkms package version to 2.17.17.0

### DIFF
--- a/scripts/enable-ecs-agent-inferentia-support.sh
+++ b/scripts/enable-ecs-agent-inferentia-support.sh
@@ -27,7 +27,8 @@ sudo mv /tmp/neuron.repo /etc/yum.repos.d/neuron.repo
 sudo yum install kernel-devel-$(uname -r) kernel-headers-$(uname -r) -y
 
 # Install Neuron Driver
-sudo yum install -y aws-neuronx-dkms-2.*
+# Pin the aws-neuronx-dkms package version to 2.17.17.0, since the newest versions of the Neuron SDK are no longer supporting linux kernel 4.14
+sudo yum install -y aws-neuronx-dkms-2.17.17.0
 sudo yum install -y aws-neuronx-oci-hook-2.*
 
 # Install oci-add-hooks


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pr pin the aws-neuronx-dkms package version to 2.17.17.0(the aws-neuron-dkms version from the last INF AMI we released) since the aws-neuronx-dkms.noarch 0:2.18.12.0-dkms package was not successfully installed during AMI build process in AMI release 20240919
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
Build a test inf ami ami-048bffbac7cedb521 and performed internal testing specific to Inferenetia functionality

```

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
