### PR TITLE
feat: Expose variables to set AMI share permisions

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -27,6 +27,9 @@ source "amazon-ebs" "al1" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns    = "${var.ami_ou_arns}"
+  ami_org_arns   = "${var.ami_org_arns}"
+  ami_users      = "${var.ami_users}"
   user_data_file = "scripts/al1/user_data.sh"
   ssh_interface  = "public_ip"
   ssh_username   = "ec2-user"

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -27,6 +27,9 @@ source "amazon-ebs" "al2" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2023" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2023arm.pkr.hcl
+++ b/al2023arm.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2023arm" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2023neu.pkr.hcl
+++ b/al2023neu.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2023neu" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {
@@ -32,4 +35,3 @@ source "amazon-ebs" "al2023neu" {
     ami_version         = "2023.0.${var.ami_version_al2023}"
   }
 }
-

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2arm" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2gpu" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2inf" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2keplergpu.pkr.hcl
+++ b/al2keplergpu.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2keplergpu" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2kernel5dot10.pkr.hcl
+++ b/al2kernel5dot10.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2kernel5dot10" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2kernel5dot10arm.pkr.hcl
+++ b/al2kernel5dot10arm.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2kernel5dot10arm" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2kernel5dot10gpu.pkr.hcl
+++ b/al2kernel5dot10gpu.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2kernel5dot10gpu" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {

--- a/al2kernel5dot10inf.pkr.hcl
+++ b/al2kernel5dot10inf.pkr.hcl
@@ -21,6 +21,9 @@ source "amazon-ebs" "al2kernel5dot10inf" {
     most_recent        = true
     include_deprecated = true
   }
+  ami_ou_arns   = "${var.ami_ou_arns}"
+  ami_org_arns  = "${var.ami_org_arns}"
+  ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
   tags = {
@@ -32,4 +35,3 @@ source "amazon-ebs" "al2kernel5dot10inf" {
     ami_version         = "2.0.${var.ami_version_al2}"
   }
 }
-

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -238,3 +238,21 @@ variable "ebs_csi_driver_version" {
   description = "EBS CSI driver version to build AMI with."
   default     = ""
 }
+
+variable "ami_ou_arns" {
+  type        = list(string)
+  description = "A list of Amazon Resource Names (ARN) of AWS Organizations organizational units (OU) that have access to launch the resulting AMI(s)."
+  default     = []
+}
+
+variable "ami_org_arns" {
+  type        = list(string)
+  description = "A list of Amazon Resource Names (ARN) of AWS Organizations that have access to launch the resulting AMI(s)."
+  default     = []
+}
+
+variable "ami_users" {
+  type        = list(string)
+  description = "A list of account IDs that have access to launch the resulting AMI(s)."
+  default     = []
+}


### PR DESCRIPTION
### Summary
Exposes the `ami_ou_arns`, `ami_org_arns`, and `ami_users` variables for configuration.
Resolves https://github.com/aws/amazon-ecs-ami/issues/30

### Implementation details
Adds three entries to `variables.tf` for these variables, and pass them through to the underlying `ebs_builder`s 

### Testing
I have built and deployed both the `al2` and `al2arm` variants. Unfortunately the `make tests` command mentioned doesnt appear to exist but im happy to run any additional tests needed. 

New tests cover the changes: no

### Description for the changelog
Feature - Support AMI sharing

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
