### PR TITLE
Update ECS Agent version to 1.88.0

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -60,7 +60,7 @@ variable "block_device_size_gb" {
 variable "ecs_agent_version" {
   type        = string
   description = "ECS agent version to build AMI with."
-  default     = "1.87.1"
+  default     = "1.88.0"
 }
 
 variable "ecs_init_rev" {


### PR DESCRIPTION
### Summary
Update ECS Agent version to 1.88.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
