### PR TITLE
pin the version of nvidia-container-toolkit

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support.sh
+++ b/scripts/enable-ecs-agent-gpu-support.sh
@@ -140,10 +140,10 @@ else
         xorg-x11-server-Xorg \
         docker-runtime-nvidia \
         oci-add-hooks \
-        libnvidia-container1 \
-        libnvidia-container-tools \
-        nvidia-container-toolkit-base \
-        nvidia-container-toolkit
+        libnvidia-container1-1.16.2 \
+        libnvidia-container-tools-1.16.2 \
+        nvidia-container-toolkit-base-1.16.2 \
+        nvidia-container-toolkit-1.16.2
 
     sudo yum install -y cuda-drivers \
         cuda


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pr update our recipe to pin the version of nvidia-container-toolkit rpms to 1.16.2 so that we don't release version 1.17.1 with known bug https://github.com/NVIDIA/nvidia-container-toolkit/issues/797. 
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
