### PR TITLE
unpin nvidia-container-toolkit version

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support.sh
+++ b/scripts/enable-ecs-agent-gpu-support.sh
@@ -140,10 +140,10 @@ else
         xorg-x11-server-Xorg \
         docker-runtime-nvidia \
         oci-add-hooks \
-        libnvidia-container1-1.16.2 \
-        libnvidia-container-tools-1.16.2 \
-        nvidia-container-toolkit-base-1.16.2 \
-        nvidia-container-toolkit-1.16.2
+        libnvidia-container1 \
+        libnvidia-container-tools \
+        nvidia-container-toolkit-base \
+        nvidia-container-toolkit
 
     sudo yum install -y cuda-drivers \
         cuda


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR unpins nvidia-container-toolkit version from 1.16.2. This is because a newer versions (>=1.17.3) are now available in AL repositories which resolve the compatibility issues for legacy container images being reported in https://github.com/NVIDIA/nvidia-container-toolkit/issues/797

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
unpin nvidia-container-toolkit version

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
