### PR TITLE
Support ECS Exec at ADC Regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ make al2
 
 ## Important Note on SSM Binaries Installation
 
-The build process includes a step to download and install Amazon SSM Agent binaries. If this step fails, the build will continue and complete normally, but the resulting AMI may lack ECS Exec functionality. To alert users to this possibility, we've implemented the following:
+The build process includes downloading and installing Amazon SSM Agent binaries for ECS Exec functionality:
 
-1. If the SSM binaries download fails, an error message will be printed to the console.
-2. The build process will continue despite this failure.
-3. To check if SSM binaries were successfully installed, look for error messages in the build logs containing "Failed to download amazon-ssm-agent.tar.gz" or "Failed to download amazon-ssm-agent.tar.gz.sig".
+1. Failed binary downloads will NOT halt AMI creation, but the resulting AMI will lack ECS Exec support. To verify, check for no "Failed to download amazon-ssm-agent.tar.gz" or "Failed to download amazon-ssm-agent.tar.gz.sig" messages in logs.
+2. The build process will stop for all other failures (such as DNS suffix resolution, GPG verification, or binary extraction).
 
 ## Additional Packages
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ export REGION=us-west-2
 echo "block_device_size_gb = 8" > ./overrides.auto.pkrvars.hcl
 make al2
 ```
+
 ## Additional Packages
 
 Any rpm package placed into the additional-packages/ directory will be uploaded to the instance and installed.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ echo "block_device_size_gb = 8" > ./overrides.auto.pkrvars.hcl
 make al2
 ```
 
+## Important Note on SSM Binaries Installation
+
+The build process includes a step to download and install Amazon SSM Agent binaries. If this step fails, the build will continue and complete normally, but the resulting AMI may lack ECS Exec functionality. To alert users to this possibility, we've implemented the following:
+
+1. If the SSM binaries download fails, an error message will be printed to the console.
+2. The build process will continue despite this failure.
+3. To check if SSM binaries were successfully installed, look for error messages in the build logs containing "Failed to download amazon-ssm-agent.tar.gz" or "Failed to download amazon-ssm-agent.tar.gz.sig".
+
 ## Additional Packages
 
 Any rpm package placed into the additional-packages/ directory will be uploaded to the instance and installed.

--- a/README.md
+++ b/README.md
@@ -35,14 +35,6 @@ export REGION=us-west-2
 echo "block_device_size_gb = 8" > ./overrides.auto.pkrvars.hcl
 make al2
 ```
-
-## Important Note on SSM Binaries Installation
-
-The build process includes downloading and installing Amazon SSM Agent binaries for ECS Exec functionality:
-
-1. Failed binary downloads will NOT halt AMI creation, but the resulting AMI will lack ECS Exec support. To verify, check for no "Failed to download amazon-ssm-agent.tar.gz" or "Failed to download amazon-ssm-agent.tar.gz.sig" messages in logs.
-2. The build process will stop for all other failures (such as DNS suffix resolution, GPG verification, or binary extraction).
-
 ## Additional Packages
 
 Any rpm package placed into the additional-packages/ directory will be uploaded to the instance and installed.

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -178,7 +178,8 @@ build {
     environment_vars = [
       "REGION=${var.region}",
       "EXEC_SSM_VERSION=${var.exec_ssm_version}",
-      "AIR_GAPPED=${var.air_gapped}"
+      "AIR_GAPPED=${var.air_gapped}",
+      "REGION_DNS_SUFFIX=${var.region_dns_suffix}"
     ]
   }
 

--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -148,7 +148,8 @@ build {
     environment_vars = [
       "REGION=${var.region}",
       "EXEC_SSM_VERSION=${var.exec_ssm_version}",
-      "AIR_GAPPED=${var.air_gapped}"
+      "AIR_GAPPED=${var.air_gapped}",
+      "REGION_DNS_SUFFIX=${var.region_dns_suffix}"
     ]
   }
 

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -26,6 +26,14 @@ get_dns_suffix() {
     echo "amazonaws.com${host_suffix}"
 }
 
+cleanup() {
+    if [ -d "/tmp/ssm-binaries" ]; then
+        rm -rf /tmp/ssm-binaries
+    fi
+}
+
+trap cleanup EXIT
+
 DNS_SUFFIX=$(get_dns_suffix)
 
 BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${EXEC_SSM_VERSION}"

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -15,7 +15,7 @@ download_or_exit_gracefully() {
 get_dns_suffix() {
     # If $REGION_DNS_SUFFIX is assigned and non-empty, use that
     if [ -n "$REGION_DNS_SUFFIX" ]; then
-        >&2 echo "Using configured DNS suffix: $REGION_DNS_SUFFIX"
+        echo >&2 "Using configured DNS suffix: $REGION_DNS_SUFFIX"
         echo "$REGION_DNS_SUFFIX"
         return
     fi

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -15,7 +15,7 @@ download_or_exit_gracefully() {
 get_dns_suffix() {
     # If $REGION_DNS_SUFFIX is assigned and non-empty, use that
     if [ -n "$REGION_DNS_SUFFIX" ]; then
-        echo "$REGION_DNS_SUFFIX"
+	echo "Using configured DNS suffix: $REGION_DNS_SUFFIX"
         return
     fi
 

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-# Attempts to download a file using curl and exits the script gracefully if the download fails.
-# Usage: download_or_exit_gracefully <url> <output_file>
-download_or_exit_gracefully() {
-    curl -fLSs "$1" -o "$2" || {
-        echo "Error: Failed to download $2"
-        exit 0
-    }
-}
-
 # Returns AWS DNS suffix from $REGION_DNS_SUFFIX if set, errors if no dns suffix set for air-gapped regions.
 # Defaults to amazonaws.com[.cn]
 get_dns_suffix() {
@@ -32,14 +23,6 @@ get_dns_suffix() {
     echo "amazonaws.com${host_suffix}"
 }
 
-cleanup() {
-    if [ -d "/tmp/ssm-binaries" ]; then
-        rm -rf /tmp/ssm-binaries
-    fi
-}
-
-trap cleanup EXIT
-
 DNS_SUFFIX=$(get_dns_suffix)
 
 BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${EXEC_SSM_VERSION}"
@@ -54,12 +37,12 @@ gpg --import /tmp/amazon-ssm-agent.gpg
 
 case $ARCHITECTURE in
 'x86_64')
-    download_or_exit_gracefully "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" "amazon-ssm-agent.tar.gz"
-    download_or_exit_gracefully "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz.sig" "amazon-ssm-agent.tar.gz.sig"
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" -o "amazon-ssm-agent.tar.gz"
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz.sig" -o "amazon-ssm-agent.tar.gz.sig"
     ;;
 'aarch64')
-    download_or_exit_gracefully "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" "amazon-ssm-agent.tar.gz"
-    download_or_exit_gracefully "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz.sig" "amazon-ssm-agent.tar.gz.sig"
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" -o "amazon-ssm-agent.tar.gz"
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz.sig" -o "amazon-ssm-agent.tar.gz.sig"
     ;;
 esac
 gpg --verify amazon-ssm-agent.tar.gz.sig amazon-ssm-agent.tar.gz

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
-if [ -n "$AIR_GAPPED" ]; then
-    echo "Air-gapped region, exec feature is not supported"
-    exit 0
-fi
+# Attempts to download a file using curl and exits the script gracefully if the download fails.
+# Usage: download_or_exit_gracefully <url> <output_file>
+download_or_exit_gracefully() {
+    curl -fLSs "$1" -o "$2" || { echo "Error: Failed to download $2"; exit 0; }
+}
 
 get_dns_suffix() {
     # If $REGION_DNS_SUFFIX is assigned and non-empty, use that
@@ -39,12 +40,12 @@ gpg --import /tmp/amazon-ssm-agent.gpg
 
 case $ARCHITECTURE in
 'x86_64')
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz || echo "Error: Failed to download amazon-ssm-agent.tar.gz"
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz.sig" -o amazon-ssm-agent.tar.gz.sig || echo "Error: Failed to download amazon-ssm-agent.tar.gz.sig"
+    download_or_exit_gracefully "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" "amazon-ssm-agent.tar.gz"
+    download_or_exit_gracefully "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz.sig" "amazon-ssm-agent.tar.gz.sig"
     ;;
 'aarch64')
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz || echo "Error: Failed to download amazon-ssm-agent.tar.gz"
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz.sig" -o amazon-ssm-agent.tar.gz.sig || echo "Error: Failed to download amazon-ssm-agent.tar.gz.sig"
+    download_or_exit_gracefully "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" "amazon-ssm-agent.tar.gz"
+    download_or_exit_gracefully "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz.sig" "amazon-ssm-agent.tar.gz.sig"
     ;;
 esac
 gpg --verify amazon-ssm-agent.tar.gz.sig amazon-ssm-agent.tar.gz

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -15,7 +15,8 @@ download_or_exit_gracefully() {
 get_dns_suffix() {
     # If $REGION_DNS_SUFFIX is assigned and non-empty, use that
     if [ -n "$REGION_DNS_SUFFIX" ]; then
-        echo "Using configured DNS suffix: $REGION_DNS_SUFFIX"
+        >&2 echo "Using configured DNS suffix: $REGION_DNS_SUFFIX"
+        echo "$REGION_DNS_SUFFIX"
         return
     fi
 

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -6,14 +6,30 @@ if [ -n "$AIR_GAPPED" ]; then
     exit 0
 fi
 
+get_dns_suffix() {
+    # If $REGION_DNS_SUFFIX is assigned and non-empty, use that
+    if [ -n "$REGION_DNS_SUFFIX" ]; then
+        echo "$REGION_DNS_SUFFIX"
+        return
+    fi
+
+    if [ -n "$AIR_GAPPED" ]; then
+        echo "Air-gapped region, need to set DNS suffix explicitly"
+        exit 1
+    fi
+
+    local host_suffix=""
+    if grep -q "^cn-" <<< "$REGION"; then
+        host_suffix=".cn"
+    fi
+    echo "amazonaws.com${host_suffix}"
+}
+
+DNS_SUFFIX=$(get_dns_suffix)
+
 BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${EXEC_SSM_VERSION}"
 CERTS_PATH="/var/lib/ecs/deps/execute-command/certs"
 ARCHITECTURE="$(uname -m)"
-
-host_suffix=""
-if grep -q "^cn-" <<<"$REGION"; then
-    host_suffix=".cn"
-fi
 
 # Download ssm agent static binaries in BINARY_PATH
 mkdir -p /tmp/ssm-binaries && cd /tmp/ssm-binaries
@@ -23,12 +39,12 @@ gpg --import /tmp/amazon-ssm-agent.gpg
 
 case $ARCHITECTURE in
 'x86_64')
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz.sig" -o amazon-ssm-agent.tar.gz.sig
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz || echo "Error: Failed to download amazon-ssm-agent.tar.gz"
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz.sig" -o amazon-ssm-agent.tar.gz.sig || echo "Error: Failed to download amazon-ssm-agent.tar.gz.sig"
     ;;
 'aarch64')
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.amazonaws.com${host_suffix}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz.sig" -o amazon-ssm-agent.tar.gz.sig
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz || echo "Error: Failed to download amazon-ssm-agent.tar.gz"
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz.sig" -o amazon-ssm-agent.tar.gz.sig || echo "Error: Failed to download amazon-ssm-agent.tar.gz.sig"
     ;;
 esac
 gpg --verify amazon-ssm-agent.tar.gz.sig amazon-ssm-agent.tar.gz

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -15,7 +15,7 @@ download_or_exit_gracefully() {
 get_dns_suffix() {
     # If $REGION_DNS_SUFFIX is assigned and non-empty, use that
     if [ -n "$REGION_DNS_SUFFIX" ]; then
-	echo "Using configured DNS suffix: $REGION_DNS_SUFFIX"
+        echo "Using configured DNS suffix: $REGION_DNS_SUFFIX"
         return
     fi
 

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -10,6 +10,8 @@ download_or_exit_gracefully() {
     }
 }
 
+# Returns AWS DNS suffix from $REGION_DNS_SUFFIX if set, errors if no dns suffix set for air-gapped regions.
+# Defaults to amazonaws.com[.cn]
 get_dns_suffix() {
     # If $REGION_DNS_SUFFIX is assigned and non-empty, use that
     if [ -n "$REGION_DNS_SUFFIX" ]; then

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -4,7 +4,10 @@ set -ex
 # Attempts to download a file using curl and exits the script gracefully if the download fails.
 # Usage: download_or_exit_gracefully <url> <output_file>
 download_or_exit_gracefully() {
-    curl -fLSs "$1" -o "$2" || { echo "Error: Failed to download $2"; exit 0; }
+    curl -fLSs "$1" -o "$2" || {
+        echo "Error: Failed to download $2"
+        exit 0
+    }
 }
 
 get_dns_suffix() {
@@ -20,7 +23,7 @@ get_dns_suffix() {
     fi
 
     local host_suffix=""
-    if grep -q "^cn-" <<< "$REGION"; then
+    if grep -q "^cn-" <<<"$REGION"; then
         host_suffix=".cn"
     fi
     echo "amazonaws.com${host_suffix}"

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -37,12 +37,12 @@ gpg --import /tmp/amazon-ssm-agent.gpg
 
 case $ARCHITECTURE in
 'x86_64')
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" -o "amazon-ssm-agent.tar.gz"
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz.sig" -o "amazon-ssm-agent.tar.gz.sig"
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_amd64/amazon-ssm-agent-binaries.tar.gz.sig" -o amazon-ssm-agent.tar.gz.sig
     ;;
 'aarch64')
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" -o "amazon-ssm-agent.tar.gz"
-    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz.sig" -o "amazon-ssm-agent.tar.gz.sig"
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz" -o amazon-ssm-agent.tar.gz
+    curl -fLSs "https://amazon-ssm-${REGION}.s3.${REGION}.${DNS_SUFFIX}/${EXEC_SSM_VERSION}/linux_arm64/amazon-ssm-agent-binaries.tar.gz.sig" -o amazon-ssm-agent.tar.gz.sig
     ;;
 esac
 gpg --verify amazon-ssm-agent.tar.gz.sig amazon-ssm-agent.tar.gz

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -268,3 +268,9 @@ variable "run_tags" {
   description = "Tags to apply to resources (key-pair, SG, IAM, snapshot, interfaces and instance) used when building the AMI."
   default     = {}
 }
+
+variable "region_dns_suffix" {
+  type        = string
+  description = "DNS Suffix to use for in region URLs"
+  default     = ""
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- Add support for specifying DNS suffixes in AMI builds
- Remove air-gapped region check and early exit

### Implementation details
<!-- How are the changes implemented? -->

### Testing
`REGION=us-west-2 make al2`

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
