### PR TITLE
Increase sleep time in release Github actions

### DIFF
--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -88,9 +88,9 @@ jobs:
     - name: Delete shinkansen branch on codecommit repository
       run: |
         aws codecommit delete-branch --repository-name amazon-ecs-ami-mirror --branch-name shinkansen
-    - name: Sleeping for 30 seconds after CodeCommit branch deletion and before recreating it
+    - name: Sleeping for 60 seconds after CodeCommit branch deletion and before recreating it
       run: |
-        sleep 30
+        sleep 60
     - name: Configure prereqs
       run: |
         git config --global user.name "Github Action"

--- a/.github/workflows/manualtrigger.yml
+++ b/.github/workflows/manualtrigger.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Delete shinkansen branch on codecommit repository
       run: |
         aws codecommit delete-branch --repository-name amazon-ecs-ami-mirror --branch-name shinkansen
-    - name: Sleeping for 30 seconds after CodeCommit branch deletion and before recreating it
+    - name: Sleeping for 60 seconds after CodeCommit branch deletion and before recreating it
       run: |
-        sleep 30
+        sleep 60
     - name: Configure prereqs
       run: |
         git config --global user.name "Github Action"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Increase the existing sleep time of 30 seconds to 60 seconds in release Github actions. For context, sleep time was first introduced as part of this pull request: https://github.com/aws/amazon-ecs-ami/pull/281. Recent release has shown that the 30 seconds sometimes it still not enough time to prevent the race condition mentioned in that pull request.

### Implementation details
See "Summary" section above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
