### PR TITLE
Skip SSM Agent installation for AL1 in Isolated Regions

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -123,6 +123,7 @@ build {
   provisioner "shell" {
     script = "scripts/install-exec-dependencies.sh"
     environment_vars = [
+      "AMI_TYPE=${source.name}",
       "REGION=${var.region}",
       "EXEC_SSM_VERSION=${var.exec_ssm_version}",
       "AIR_GAPPED=${var.air_gapped}"

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -181,6 +181,7 @@ build {
   provisioner "shell" {
     script = "scripts/install-exec-dependencies.sh"
     environment_vars = [
+      "AMI_TYPE=${source.name}",
       "REGION=${var.region}",
       "EXEC_SSM_VERSION=${var.exec_ssm_version}",
       "AIR_GAPPED=${var.air_gapped}",

--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -152,6 +152,7 @@ build {
   provisioner "shell" {
     script = "scripts/install-exec-dependencies.sh"
     environment_vars = [
+      "AMI_TYPE=${source.name}",
       "REGION=${var.region}",
       "EXEC_SSM_VERSION=${var.exec_ssm_version}",
       "AIR_GAPPED=${var.air_gapped}",

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-if [[ -n "$AIR_GAPPED" && "$AMI_TYPE" = "al1" ]]; then
+if [[ -n $AIR_GAPPED && $AMI_TYPE == "al1" ]]; then
     echo "For Air-gapped region, exec feature is not supported for AL1 AMIs"
     exit 0
 fi

--- a/scripts/install-exec-dependencies.sh
+++ b/scripts/install-exec-dependencies.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
+if [[ -n "$AIR_GAPPED" && "$AMI_TYPE" = "al1" ]]; then
+    echo "For Air-gapped region, exec feature is not supported for AL1 AMIs"
+    exit 0
+fi
+
 # Returns AWS DNS suffix from $REGION_DNS_SUFFIX if set, errors if no dns suffix set for air-gapped regions.
 # Defaults to amazonaws.com[.cn]
 get_dns_suffix() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Recently Exec feature support was extended to Isolated regions as part of https://github.com/aws/amazon-ecs-ami/pull/368. This support is not extended for AL1 AMI builds, as ECS AL1 is EOL and no new support is introduced.

Currently, AL1 AMI builds can fail in isolated region due to failure to download SSM Agent binaries. This is because a proper [DNS suffix](https://github.com/aws/amazon-ecs-ami/blob/ce5990009809ac0306af9610a36dd180258f316c/scripts/install-exec-dependencies.sh#L8) is not passed through to AL1 exec dependencies download script.

This PR skips SSM Agent binaries installation in isolated regions, only for AL1 builds.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Tested successful AL1 and AL2 AMI builds

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Skip SSM Agent installation for AL1 in Isolated Regions

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
