### PR TITLE
Bump docker version to 25.0.8 and runc version to 1.2.4

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -72,7 +72,7 @@ variable "ecs_init_rev" {
 variable "docker_version" {
   type        = string
   description = "Docker version to build AMI with."
-  default     = "25.0.6"
+  default     = "25.0.8"
 }
 
 variable "containerd_version" {
@@ -84,13 +84,13 @@ variable "containerd_version" {
 variable "runc_version" {
   type        = string
   description = "Runc version to build AMI with."
-  default     = "1.1.14"
+  default     = "1.2.4"
 }
 
 variable "docker_version_al2023" {
   type        = string
   description = "Docker version to build AL2023 AMI with."
-  default     = "25.0.6"
+  default     = "25.0.8"
 }
 
 variable "containerd_version_al2023" {
@@ -102,7 +102,7 @@ variable "containerd_version_al2023" {
 variable "runc_version_al2023" {
   type        = string
   description = "Runc version to build AL2023 AMI with."
-  default     = "1.1.14"
+  default     = "1.2.4"
 }
 
 variable "exec_ssm_version" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Bump docker version to 25.0.8 and runc version to 1.2.4

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
