### PR TITLE
Remove AL1 AMI build automation

### DIFF
--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -1,8 +1,8 @@
 name: InitiateRelease
 
-on: 
+on:
   workflow_dispatch:
-  schedule: 
+  schedule:
     - cron: 0 18 * * 1-5
 
 jobs:
@@ -16,8 +16,8 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
-    env: 
-      IAM_INSTANCE_PROFILE_ARN: ${{ secrets.IAM_INSTANCE_PROFILE_ARN }} 
+    env:
+      IAM_INSTANCE_PROFILE_ARN: ${{ secrets.IAM_INSTANCE_PROFILE_ARN }}
       GH_TOKEN: ${{ github.token }}
     steps:
     - name: Checkout
@@ -28,19 +28,17 @@ jobs:
         git checkout -b release-${date}
     - name: Install xmllint
       run: |
-        # generate-release-vars.sh depends on these packages 
+        # generate-release-vars.sh depends on these packages
         sudo apt-get update && sudo apt-get install libxml2-utils
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
-      with: 
+      with:
         role-to-assume: ${{ secrets.AMI_GENERATE_CONFIG_ROLE }}
         aws-region: us-west-2
     - name: Configure Bot Alias
       run: |
         git config --global user.name "GenerateConfig Action"
         git config --global user.email "gcaction@github.com"
-    - name: Check AL1 Update
-      run: ./scripts/check-update.sh al1
     - name: Check AL2 Update
       run: ./scripts/check-update.sh al2
     - name: Check AL2023 Update
@@ -51,7 +49,7 @@ jobs:
         # Git diff returns exit code of 1 when there is a change staged
         # We need the set statements to prevent erroring out
         set +e
-        git diff --cached --quiet 
+        git diff --cached --quiet
         echo "stage_exit_code=$?" >> "$GITHUB_OUTPUT"
         set -e
     - name: Commit and Push Changes
@@ -63,7 +61,7 @@ jobs:
         git status
         git push --set-upstream origin release-${date}
         echo "push_exit_code=$?" >> "$GITHUB_OUTPUT"
-    - name: Open PR for Branch 
+    - name: Open PR for Branch
       id: pr
       if: ${{ steps.stage.outputs.stage_exit_code == 1 && steps.push.outputs.push_exit_code == 0 }}
       run: |
@@ -82,7 +80,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
-      with: 
+      with:
         role-to-assume: ${{secrets.AMI_MIRROR_ROLE}}
         aws-region: us-west-2
     - name: Delete shinkansen branch on codecommit repository
@@ -97,7 +95,7 @@ jobs:
         git config --global user.email "action@github.com"
         pip install git-remote-codecommit
     - name: Mirror to shinkansen branch on codecommit repository
-      run: | 
+      run: |
         date=$(date '+%Y%m%d')
         git clone --single-branch --branch release-${date} https://github.com/aws/amazon-ecs-ami ecsAmiGithub
         git clone codecommit::us-west-2://amazon-ecs-ami-mirror ecsAmiCodeCommit
@@ -119,7 +117,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
-      with: 
+      with:
         role-to-assume: ${{secrets.AMI_MIRROR_ROLE}}
         aws-region: us-west-2
     - name: Failure Scenario


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->

AL1 is End-of-Life, this removes the AL1 AMI release automation check. AL1 can still be built but the release automation is removed.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

NA

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
