### PR TITLE
Explicitly install kernel-devel in enable-ecs-agent-gpu-support-al2023.sh

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support-al2023.sh
+++ b/scripts/enable-ecs-agent-gpu-support-al2023.sh
@@ -8,7 +8,7 @@ fi
 
 ### Install GPU Drivers and Required Packages
 # Install base requirements
-sudo dnf install -y dkms kernel-modules-extra
+sudo dnf install -y dkms kernel-modules-extra kernel-devel-$(uname -r)
 
 # Enable DKMS service
 sudo systemctl enable --now dkms


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR contains changes to the enable-ecs-agent-gpu-support-al2023.sh file to explicitly install the kernel-devel package that corresponds to 6.1 kernel on AL2023.

In AL2023 version 2023.7.20250331 release, kernel 6.12 was launched. With this launch the kernel-headers packages had a 6.12 version launched as well.


In  enable gpu support for AL23 script https://github.com/aws/amazon-ecs-ami/blob/main/scripts/enable-ecs-agent-gpu-support-al2023.sh#L20, it installs`nvidia-driver` which will install `kernel-headers` as a dependency.

Issue is that with the install of `nvidia-driver` it automatically installs the 6.12 version of `kernel-headers`. For nvidia GPU drivers to work properly, the `kernel-headers ` package have to be of a similar version of the kernel as well.

### Implementation details
<!-- How are the changes implemented? -->
Added `kernel-devel-$(uname -r)` to the install script
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

<details>
<summary>Tested AMIs by running the following script:</summary>
<br>

```
#!/bin/bash
set -x

if ! ls -la /dev/nvidia*; then
    echo "No nvidia devices found"
    exit 1
fi

if ! command -v nvidia-smi; then
    echo "nvidia-smi tool not found"
	exit 2
fi

set -e
ls -la /dev/nvidia*
nvidia-smi -L
set +e

n_devices=$(nvidia-smi -L | wc -l)
for i in $(seq 1 "$n_devices"); do
    dev_number=$(expr $i - 1)
    if [ ! -c "/dev/nvidia${dev_number}" ]; then
        echo "/dev/nvidia${dev_number} not found"
        exit 3
    fi
done

if ! systemctl is-enabled  nvidia-persistenced >/dev/null; then
	echo "nvidia-persistenced is not enabled"
	exit 4
fi

exit 42
```
</details>

New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Explicitly install kernel-devel

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
