### PR TITLE
Pinning kernel version to 5.10.235* and downgrading agent version back to 1.93.0

### DIFF
--- a/scripts/al2/install-kernel5dot10.sh
+++ b/scripts/al2/install-kernel5dot10.sh
@@ -5,6 +5,7 @@
 set -ex
 
 if [[ $AMI_TYPE == "al2kernel5dot10"* ]]; then
-    sudo amazon-linux-extras install -y kernel-5.10
+    sudo amazon-linux-extras enable kernel-5.10
+    sudo yum install -y kernel-5.10.235
     sudo rpm -e kernel-4.*
 fi

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -60,7 +60,7 @@ variable "block_device_size_gb" {
 variable "ecs_agent_version" {
   type        = string
   description = "ECS agent version to build AMI with."
-  default     = "1.93.1"
+  default     = "1.93.0"
 }
 
 variable "ecs_init_rev" {


### PR DESCRIPTION

### Summary
This PR will pin the kernel version to 5.10.235* for AL2 5.10 AMIs specifically and downgrading agent version back to 1.93.0.

### Implementation details
install-kernel5dot10.sh will now be running the following commands

```
sudo amazon-linux-extras enable kernel-5.10
sudo yum install -y kernel-5.10.235
```

### Testing
Manually built a AL2 5.10 AMD and ARM AMI

Tested that the kernel version 

```
[ec2-user@ip-172-31-30-34 ~]$ uname -r
5.10.235-227.919.amzn2.aarch64
```

```
[ec2-user@ip-172-31-19-152 ~]$ uname -r
5.10.235-227.919.amzn2.x86_64
```

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Bugfix - Pinning kernel version to 5.10.235* and downgrading agent version back to 1.93.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
