### PR TITLE
Release 20250515

### DIFF
--- a/release-al2.auto.pkrvars.hcl
+++ b/release-al2.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
-ami_version_al2               = "20250514"
-ecs_agent_version             = "1.93.1"
+ami_version_al2               = "20250515"
+ecs_agent_version             = "1.93.0"
 ecs_init_rev                  = "1"
 docker_version                = "25.0.8"
 containerd_version            = "1.7.27"

--- a/release-al2023.auto.pkrvars.hcl
+++ b/release-al2023.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
-ami_version_al2023          = "20250514"
-ecs_agent_version           = "1.93.1"
+ami_version_al2023          = "20250505"
+ecs_agent_version           = "1.93.0"
 ecs_init_rev                = "1"
 docker_version_al2023       = "25.0.8"
 containerd_version_al2023   = "1.7.27"


### PR DESCRIPTION
### Release 20250515

ECS Optimized AMI Release  20250515


Rolled back AL2023 AMI version to previous `20250505` version.