### PR TITLE
Upgrade amazon-ssm-agent to version 3.3.2299.0

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -108,7 +108,7 @@ variable "runc_version_al2023" {
 variable "exec_ssm_version" {
   type        = string
   description = "SSM binary version to build ECS exec support with."
-  default     = "3.3.1802.0"
+  default     = "3.3.2299.0"
 }
 
 variable "source_ami_al2" {


### PR DESCRIPTION
### Summary
Upgrade amazon-ssm-agent to version [3.3.2299.0](https://github.com/aws/amazon-ssm-agent/releases/tag/3.3.2299.0)

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Update SSM Agent version to 3.3.2299.0 for ECS exec

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
