### PR TITLE
Unpin kernel version

### DIFF
--- a/scripts/al2/install-kernel5dot10.sh
+++ b/scripts/al2/install-kernel5dot10.sh
@@ -5,7 +5,6 @@
 set -ex
 
 if [[ $AMI_TYPE == "al2kernel5dot10"* ]]; then
-    sudo amazon-linux-extras enable kernel-5.10
-    sudo yum install -y kernel-5.10.235
+    sudo amazon-linux-extras install -y kernel-5.10
     sudo rpm -e kernel-4.*
 fi


### PR DESCRIPTION
### Summary
Undo #437 to unpin kernel version from 5.10.235*
Agent version was already upgraded in #442 


### Implementation details
Undo #437 to unpin kernel version from 5.10.235*


### Testing
Build custom AMIs (AL2 Kernel 5.10 AMD and AL2  Kernel 5.10 ARM) with this PR code changes and using the latest AL2 source AMI per #445 
SSH-ed into instances and ran these commands
```
sh-4.2$ uname -r
5.10.237-230.948.amzn2.aarch64
sh-4.2$ cat /sys/fs/cgroup/blkio/blkio.throttle.io_service_bytes | tail -1
Total 1770810880


---

sh-4.2$ uname -r
5.10.237-230.948.amzn2.x86_64
sh-4.2$ cat /sys/fs/cgroup/blkio/blkio.throttle.io_service_bytes | tail -1
Total 638600192
```
The above shows that disk metrics are being reported

New tests cover the changes: no

### Description for the changelog
Bugfix - Unpin kernel version from 5.10.235*

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
