### PR TITLE
Enable rngd service on boot

### DIFF
--- a/scripts/enable-services.sh
+++ b/scripts/enable-services.sh
@@ -4,3 +4,4 @@ set -ex
 sudo systemctl enable ecs
 sudo systemctl enable amazon-ecs-volume-plugin
 sudo systemctl enable amazon-ssm-agent
+sudo systemctl enable rngd


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Amazon Linux 2023 disabled rngd by default in their latest release. This change re-enables rngd at boot time to maintain consistency with our existing AMI behavior and expectations.
### Implementation details
<!-- How are the changes implemented? -->
* Added `systemctl enable rngd` during AMI build

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* Built an AMI using this change and ran the following commands
```
# sudo systemctl is-enabled rngd
enabled

# sudo systemctl show -p SubState rngd
SubState=running

# sudo systemctl status rngd
● rngd.service - Hardware RNG Entropy Gatherer Daemon
     Loaded: loaded (/usr/lib/systemd/system/rngd.service; enabled; preset: disabled)
     Active: active (running) since Thu 2025-06-05 23:28:24 UTC; 2min 24s ago
   Main PID: 1953 (rngd)
      Tasks: 2 (limit: 1110)
     Memory: 1.4M
        CPU: 10.134s
     CGroup: /system.slice/rngd.service
             └─1953 /usr/sbin/rngd -f -x pkcs11 -x nist

Jun 05 23:28:24 localhost systemd[1]: Started rngd.service - Hardware RNG Entropy Gatherer Daemon.
Jun 05 23:28:25 localhost rngd[1953]: Disabling 7: PKCS11 Entropy generator (pkcs11)
Jun 05 23:28:25 localhost rngd[1953]: Disabling 5: NIST Network Entropy Beacon (nist)
Jun 05 23:28:25 localhost rngd[1953]: Initializing available sources
Jun 05 23:28:25 localhost rngd[1953]: [hwrng ]: Initialization Failed
Jun 05 23:28:25 localhost rngd[1953]: [rdrand]: Enabling RDRAND rng support
Jun 05 23:28:25 localhost rngd[1953]: [rdrand]: Initialized
Jun 05 23:28:25 localhost rngd[1953]: [jitter]: Initializing AES buffer
Jun 05 23:28:30 ip-172-31-46-149.us-west-2.compute.internal rngd[1953]: [jitter]: Enabling JITTER rng support
Jun 05 23:28:30 ip-172-31-46-149.us-west-2.compute.internal rngd[1953]: [jitter]: Initialized
```

New tests cover the changes: <!-- yes|no --> N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enable rngd service on boot
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
