### PR TITLE
Update amazon-ssm-agent version for exec to 3.3.2299.0

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -108,7 +108,7 @@ variable "runc_version_al2023" {
 variable "exec_ssm_version" {
   type        = string
   description = "SSM binary version to build ECS exec support with."
-  default     = "3.3.1802.0"
+  default     = "3.3.2299.0"
 }
 
 variable "source_ami_al2" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will bump up the amazon-ssm-agent version to 3.3.2299.0 which includes a fix for CVE-2025-22869.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
Built alpha AMIs on different platforms and ran our functional tests against them. All have passed and verified that the install SSM agent version is `3.3.2299.0`

```
[ec2-user@ip-172-31-17-18 ~]$ yum list installed amazon-ssm-agent
Loaded plugins: priorities, update-motd, upgrade-helper
Installed Packages
amazon-ssm-agent.x86_64                                                                                         3.3.2299.0-1.amzn2  
```

New tests cover the changes: <!-- yes|no -->

### Description for the changelog

Enhancement - Update amazon-ssm-agent version for exec to 3.3.2299.0 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
