### PR TITLE
Bump containerd to 2.0.5, runc to 1.2.6

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -78,13 +78,13 @@ variable "docker_version" {
 variable "containerd_version" {
   type        = string
   description = "Containerd version to build AMI with."
-  default     = "1.7.27"
+  default     = "2.0.5"
 }
 
 variable "runc_version" {
   type        = string
   description = "Runc version to build AMI with."
-  default     = "1.2.4"
+  default     = "1.2.6"
 }
 
 variable "docker_version_al2023" {
@@ -96,13 +96,13 @@ variable "docker_version_al2023" {
 variable "containerd_version_al2023" {
   type        = string
   description = "Containerd version to build AL2023 AMI with."
-  default     = "1.7.27"
+  default     = "2.0.5"
 }
 
 variable "runc_version_al2023" {
   type        = string
   description = "Runc version to build AL2023 AMI with."
-  default     = "1.2.4"
+  default     = "1.2.6"
 }
 
 variable "exec_ssm_version" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Bump containerd version to 2.0.5, runc version to 1.2.6

Addresses 
- [CVE-2025-22874](https://explore.alas.aws.amazon.com/CVE-2025-22874.html)
- [CVE-2025-4673](https://explore.alas.aws.amazon.com/CVE-2025-4673.html)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Docker qualification was run.

AMI builds were manually run for AL2 and AL2023.

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix: bump containerd version to 2.0.5, runc version to 1.2.6

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
