### PR TITLE
Add AL2 EOL notice to README and MOTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ECS-optimized AMI Build Recipes
 > [!IMPORTANT]
-> The ECS-optimized Amazon Linux AMI (also called Amazon Linux 1) will reach its end of life on September 15, 2025. We encourage customers to upgrade their applications to use Amazon Linux 2023, which includes long term support through 2028.
+> The ECS-optimized Amazon Linux 1 AMI (AL1) will reach its end-of-life (EOL) on September 15, 2025.
+> The ECS-optimized Amazon Linux 2 AMI (AL2) will reach its EOL on June 30, 2026, mirroring the same EOL date of the upstream [Amazon Linux 2 Operating System](https://aws.amazon.com/amazon-linux-2/faqs).
+> We encourage customers to upgrade their applications to use Amazon Linux 2023, which includes long term support through 2028.
 
 This is a [packer](https://packer.io) recipe for creating an ECS-optimized AMI.
 It will create a private AMI in whatever account you are running it in.
@@ -8,7 +10,7 @@ It will create a private AMI in whatever account you are running it in.
 ## Instructions
 
 1. Setup AWS cli credentials.
-2. Make the recipe that you want, REGION must be specified. Options are: al1, al2, al2arm, al2gpu, al2keplergpu, al2inf, 
+2. Make the recipe that you want, REGION must be specified. Options are: al1, al2, al2arm, al2gpu, al2keplergpu, al2inf,
 al2kernel5dot10, al2kernel5dot10arm, al2kernel5dot10gpu, al2kernel5dot10inf, al2023, al2023arm, al2023neu, al2023gpu.
 ```
 REGION=us-west-2 make al2

--- a/files/29-ecs-banner-begin.sh.amzn2
+++ b/files/29-ecs-banner-begin.sh.amzn2
@@ -20,7 +20,12 @@ echo -e "
    _|  (   \__ \   Amazon Linux 2 (ECS Optimized)
  ____|\___|____/
 
-For documentation, visit http://aws.amazon.com/documentation/ecs"
+AL2 End of Life is 2026-06-30.
+
+A newer version of Amazon Linux is available!
+
+Amazon Linux 2023, GA and supported until 2028-03-15.
+  https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI"
 
 # Disable system-release banner during update-motd, reverted with
 # 31-ecs-banner-finish.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Adds a notice regarding EOL of the AL2 ECS-optimized AMI to the README of this repo, and to the MOTD displayed when logging into the AL2 ECS-optimized AMI.

This MOTD message mirrors the same text that the upstream vanilla AL2 AMI displays: 
```
   ,     #_
   ~\_  ####_        Amazon Linux 2
  ~~  \_#####\
  ~~     \###|       AL2 End of Life is 2026-06-30.
  ~~       \#/ ___
   ~~       V~' '->
    ~~~         /    A newer version of Amazon Linux is available!
      ~~._.   _/
         _/ _/       Amazon Linux 2023, GA and supported until 2028-03-15.
       _/m/'           https://aws.amazon.com/linux/amazon-linux-2023/
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

AL2 AMI was built and verified that the MOTD displays correctly

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: Add AL2 EOL messaging

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
