### PR TITLE
Change README default instructions from al2 to al2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It will create a private AMI in whatever account you are running it in.
 2. Make the recipe that you want, REGION must be specified. Options are: al1, al2, al2arm, al2gpu, al2keplergpu, al2inf,
 al2kernel5dot10, al2kernel5dot10arm, al2kernel5dot10gpu, al2kernel5dot10inf, al2023, al2023arm, al2023neu, al2023gpu.
 ```
-REGION=us-west-2 make al2
+REGION=us-west-2 make al2023
 ```
 
 **NOTE**: `al2keplergpu` is a build recipe that this package supports to build ECS-Optimized GPU AMIs for instances with GPUs
@@ -37,7 +37,7 @@ of 30 GB like this:
 ```
 export REGION=us-west-2
 echo "block_device_size_gb = 8" > ./overrides.auto.pkrvars.hcl
-make al2
+make al2023
 ```
 
 ## Additional Packages


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Update README to default to al2023



### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
