### PR TITLE
fix: match spacing for release-al2023.auto.pkrvars.hcl

### DIFF
--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -102,17 +102,17 @@ EOF
     readonly exec_ssm_version=$(sed -n '/variable "exec_ssm_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
 
     cat >|release-al2023.auto.pkrvars.hcl <<EOF
-ami_version_al2023          = "$ami_version"
-ecs_agent_version           = "$ecs_agent_version"
-ecs_init_rev                = "$ecs_init_rev"
-docker_version_al2023       = "$docker_version_al2023"
-containerd_version_al2023   = "$containerd_version_al2023"
-runc_version_al2023         = "$runc_version_al2023"
-exec_ssm_version            = "$exec_ssm_version"
-source_ami_al2023           = "$ami_name_al2023_x86"
-source_ami_al2023arm        = "$ami_name_al2023_arm"
-kernel_version_al2023       = "$kernel_version_al2023_x86"
-kernel_version_al2023arm    = "$kernel_version_al2023_arm"
+ami_version_al2023        = "$ami_version"
+ecs_agent_version         = "$ecs_agent_version"
+ecs_init_rev              = "$ecs_init_rev"
+docker_version_al2023     = "$docker_version_al2023"
+containerd_version_al2023 = "$containerd_version_al2023"
+runc_version_al2023       = "$runc_version_al2023"
+exec_ssm_version          = "$exec_ssm_version"
+source_ami_al2023         = "$ami_name_al2023_x86"
+source_ami_al2023arm      = "$ami_name_al2023_arm"
+kernel_version_al2023     = "$kernel_version_al2023_x86"
+kernel_version_al2023arm  = "$kernel_version_al2023_arm"
 EOF
     ;;
 *)


### PR DESCRIPTION
### Summary
Fixed spacing inconsistency between `release-al2023.auto.pkrvars.hcl` and `generate-release-vars.sh` that was causing false positives in daily checks. PR #491 demonstrates this issue.

#### Context
PR #489 updated the spacing in `release-al2023.auto.pkrvars.hcl`, but the space changes were not done in `generate-release-vars.sh`. This discrepancy led to daily checks detecting differences between the old and new release configuration files, which should only occur when there are changes in package dependencies.





### Implementation details
Removed extra spacing in `generate-release-vars.sh` to match the ones in the `release-al2023.auto.pkrvars.hcl`


### Testing
Ran `./generate-release-vars.sh al2023`
Confirmed that the only change is `ami_version_al2023` entry
```
diff --git a/release-al2023.auto.pkrvars.hcl b/release-al2023.auto.pkrvars.hcl
index 10b98f9..65ec1aa 100644
--- a/release-al2023.auto.pkrvars.hcl
+++ b/release-al2023.auto.pkrvars.hcl
@@ -1,4 +1,4 @@
-ami_version_al2023        = "20250725"
+ami_version_al2023        = "20250729"
 ecs_agent_version         = "1.96.0"
 ecs_init_rev              = "1"
 docker_version_al2023     = "25.0.8"
```


New tests cover the changes: no

### Description for the changelog
bugfix: Fixed spacing inconsistency in release configuration files

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
