### PR TITLE
Support instance type override for AMI builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,59 +51,59 @@ validate: check-region init
 
 .PHONY: al1
 al1: check-region init validate release-al1.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al1" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al1" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2
 al2: check-region init validate release-al2.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2arm
 al2arm: check-region init validate release-al2.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2arm" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2arm" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2gpu
 al2gpu: check-region init validate release-al2.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2gpu" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2gpu" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2keplergpu
 al2keplergpu: check-region init validate release-al2.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2keplergpu" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2keplergpu" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2inf
 al2inf: check-region init validate release-al2.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2inf" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2inf" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2kernel5dot10
 al2kernel5dot10: check-region init validate release-al2.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2kernel5dot10" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2kernel5dot10" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2kernel5dot10arm
 al2kernel5dot10arm: check-region init validate release-al2.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2kernel5dot10arm" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2kernel5dot10arm" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2kernel5dot10gpu
 al2kernel5dot10gpu: check-region init validate release-al2.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2kernel5dot10gpu" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2kernel5dot10gpu" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2kernel5dot10inf
 al2kernel5dot10inf: check-region init validate release-al2.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2kernel5dot10inf" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2kernel5dot10inf" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2023
 al2023: check-region init validate release-al2023.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2023" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2023" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2023arm
 al2023arm: check-region init validate release-al2023.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2023arm" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2023arm" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2023neu
 al2023neu: check-region init validate release-al2023.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2023neu" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2023neu" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 .PHONY: al2023gpu
 al2023gpu: check-region init validate release-al2023.auto.pkrvars.hcl
-	./packer build -only="amazon-ebs.al2023gpu" -var "region=${REGION}" .
+	./packer build -only="amazon-ebs.al2023gpu" -var "region=${REGION}" -var "instance_type_override=${INSTANCE_TYPE}" .
 
 shellcheck:
 	curl -fLSs ${SHELLCHECK_URL} -o /tmp/shellcheck.tar.xz

--- a/README.md
+++ b/README.md
@@ -10,10 +10,18 @@ It will create a private AMI in whatever account you are running it in.
 ## Instructions
 
 1. Setup AWS cli credentials.
-2. Make the recipe that you want, REGION must be specified. Options are: al1, al2, al2arm, al2gpu, al2keplergpu, al2inf,
-al2kernel5dot10, al2kernel5dot10arm, al2kernel5dot10gpu, al2kernel5dot10inf, al2023, al2023arm, al2023neu, al2023gpu.
+2. Make the recipe that you want. REGION must be specified. INSTANCE_TYPE can be specified if desired. Options are: 
+al1, al2, al2arm, al2gpu, al2keplergpu, al2inf, al2kernel5dot10, al2kernel5dot10arm, al2kernel5dot10gpu, 
+al2kernel5dot10inf, al2023, al2023arm, al2023neu, al2023gpu.
+
+Example without INSTANCE_TYPE specified:
 ```
 REGION=us-west-2 make al2023
+```
+
+Example with INSTANCE_TYPE specified:
+```
+REGION=ap-east-2 INSTANCE_TYPE=c6i.large make al2023
 ```
 
 **NOTE**: `al2keplergpu` is a build recipe that this package supports to build ECS-Optimized GPU AMIs for instances with GPUs

--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al1" {
   ami_name        = "${local.ami_name_al1}"
   ami_description = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version_al1} x86_64 ECS HVM GP2"
-  instance_type   = var.general_purpose_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.general_purpose_instance_types[0])
   launch_block_device_mappings {
     volume_size           = 8
     delete_on_termination = true

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -20,7 +20,7 @@ locals {
 source "amazon-ebs" "al2" {
   ami_name        = "${local.ami_name_al2}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
-  instance_type   = var.general_purpose_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.general_purpose_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2023" {
   ami_name        = "${local.ami_name_al2023}"
   ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} x86_64 ECS HVM EBS"
-  instance_type   = var.general_purpose_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.general_purpose_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2023arm.pkr.hcl
+++ b/al2023arm.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2023arm" {
   ami_name        = "${local.ami_name_al2023arm}"
   ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} arm64 ECS HVM EBS"
-  instance_type   = var.arm_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.arm_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2023gpu.pkr.hcl
+++ b/al2023gpu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2023gpu" {
   ami_name        = "${local.ami_name_al2023gpu}"
   ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} x86_64 ECS HVM EBS"
-  instance_type   = var.gpu_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.gpu_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2023neu.pkr.hcl
+++ b/al2023neu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2023neu" {
   ami_name        = "${local.ami_name_al2023neu}"
   ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} x86_64 ECS HVM EBS"
-  instance_type   = var.neu_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.neu_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2arm" {
   ami_name        = "${local.ami_name_al2arm}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} arm64 ECS HVM GP2"
-  instance_type   = var.arm_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.arm_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2gpu" {
   ami_name        = "${local.ami_name_al2gpu}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
-  instance_type   = var.gpu_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.gpu_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2inf" {
   ami_name        = "${local.ami_name_al2inf}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
-  instance_type   = var.inf_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.inf_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2keplergpu.pkr.hcl
+++ b/al2keplergpu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2keplergpu" {
   ami_name        = "${local.ami_name_al2keplergpu}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
-  instance_type   = var.gpu_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.gpu_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10.pkr.hcl
+++ b/al2kernel5dot10.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2kernel5dot10" {
   ami_name        = "${local.ami_name_al2kernel5dot10}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 x86_64 ECS HVM GP2"
-  instance_type   = var.general_purpose_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.general_purpose_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10arm.pkr.hcl
+++ b/al2kernel5dot10arm.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2kernel5dot10arm" {
   ami_name        = "${local.ami_name_al2kernel5dot10arm}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 arm64 ECS HVM GP2"
-  instance_type   = var.arm_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.arm_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10gpu.pkr.hcl
+++ b/al2kernel5dot10gpu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2kernel5dot10gpu" {
   ami_name        = "${local.ami_name_al2kernel5dot10gpu}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 x86_64 ECS HVM GP2"
-  instance_type   = var.gpu_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.gpu_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10inf.pkr.hcl
+++ b/al2kernel5dot10inf.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2kernel5dot10inf" {
   ami_name        = "${local.ami_name_al2kernel5dot10inf}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 x86_64 ECS HVM GP2"
-  instance_type   = var.inf_instance_types[0]
+  instance_type   = coalesce(var.instance_type_override, var.inf_instance_types[0])
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -192,6 +192,12 @@ variable "ecs_init_local_override" {
   default     = ""
 }
 
+variable "instance_type_override" {
+  type        = string
+  description = "Specify a specific instance type to build the AMI with."
+  default     = ""
+}
+
 variable "general_purpose_instance_types" {
   type        = list(string)
   description = "List of available in-region instance types for general-purpose platform"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Support instance type override for AMI builds. This unblocks users of `amazon-ecs-ami` to be able to easily provide a custom instance type to use for building ECS-Optimized AMIs. This change is necessary because instance types hardcoded in the repository which are currently used may not be available in a given region. Furthermore, AWS may have insufficient capacity for a given instance type in a given region at any given time.

For example, instance type `c5.large` (which is hardcoded [here](https://github.com/aws/amazon-ecs-ami/blob/main/variables.pkr.hcl#L198)) is not available in newer regions such as  `ap-southeast-7`, `mx-central-1`, and `ap-east-2`. 

### Implementation details
<!-- How are the changes implemented? -->
- Create new variable `instance_type_override`
- Update Makefile targets for reach ECS-Optimized AMI variant to set `instance_type_override` variable
- Use `var.instance_type_override` as instance type to build AMIs with if non-empty
- Update README to document support of this optional functionality

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Build ECS-Optimized AMI `al2023` variant in `ap-east-2` region while specifying `c6i.large` instance type. Confirm that build succeeds and uses instance type `c6i.large` instance type to build the AMI:
```
% REGION=ap-east-2 INSTANCE_TYPE=c6i.large make al2023
...
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2023: AMIs were created:
...
```

Build ECS-Optimized AMI `al2kernel5dot10` variant in `us-west-2` region while not specifying instance type. Confirm that build succeeds and uses instance type `c5.large` instance type to build the AMI:
```
% REGION=us-west-2 make al2kernel5dot10
...
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2kernel5dot10: AMIs were created:
...
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Support instance type override for AMI builds

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
