### PR TITLE
Simplify instance type vars from list(string) to string

### DIFF
--- a/al1.pkr.hcl
+++ b/al1.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al1" {
   ami_name        = "${local.ami_name_al1}"
   ami_description = "Amazon Linux AMI amzn-ami-2018.03.${var.ami_version_al1} x86_64 ECS HVM GP2"
-  instance_type   = var.general_purpose_instance_types[0]
+  instance_type   = var.general_purpose_instance_type
   launch_block_device_mappings {
     volume_size           = 8
     delete_on_termination = true

--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -20,7 +20,7 @@ locals {
 source "amazon-ebs" "al2" {
   ami_name        = "${local.ami_name_al2}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
-  instance_type   = var.general_purpose_instance_types[0]
+  instance_type   = var.general_purpose_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2023" {
   ami_name        = "${local.ami_name_al2023}"
   ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} x86_64 ECS HVM EBS"
-  instance_type   = var.general_purpose_instance_types[0]
+  instance_type   = var.general_purpose_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2023arm.pkr.hcl
+++ b/al2023arm.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2023arm" {
   ami_name        = "${local.ami_name_al2023arm}"
   ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} arm64 ECS HVM EBS"
-  instance_type   = var.arm_instance_types[0]
+  instance_type   = var.arm_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2023gpu.pkr.hcl
+++ b/al2023gpu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2023gpu" {
   ami_name        = "${local.ami_name_al2023gpu}"
   ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} x86_64 ECS HVM EBS"
-  instance_type   = var.gpu_instance_types[0]
+  instance_type   = var.gpu_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2023neu.pkr.hcl
+++ b/al2023neu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2023neu" {
   ami_name        = "${local.ami_name_al2023neu}"
   ami_description = "Amazon Linux AMI 2023.0.${var.ami_version_al2023} x86_64 ECS HVM EBS"
-  instance_type   = var.neu_instance_types[0]
+  instance_type   = var.neu_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2arm" {
   ami_name        = "${local.ami_name_al2arm}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} arm64 ECS HVM GP2"
-  instance_type   = var.arm_instance_types[0]
+  instance_type   = var.arm_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2gpu" {
   ami_name        = "${local.ami_name_al2gpu}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
-  instance_type   = var.gpu_instance_types[0]
+  instance_type   = var.gpu_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2inf" {
   ami_name        = "${local.ami_name_al2inf}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
-  instance_type   = var.inf_instance_types[0]
+  instance_type   = var.inf_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2keplergpu.pkr.hcl
+++ b/al2keplergpu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2keplergpu" {
   ami_name        = "${local.ami_name_al2keplergpu}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} x86_64 ECS HVM GP2"
-  instance_type   = var.gpu_instance_types[0]
+  instance_type   = var.gpu_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10.pkr.hcl
+++ b/al2kernel5dot10.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2kernel5dot10" {
   ami_name        = "${local.ami_name_al2kernel5dot10}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 x86_64 ECS HVM GP2"
-  instance_type   = var.general_purpose_instance_types[0]
+  instance_type   = var.general_purpose_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10arm.pkr.hcl
+++ b/al2kernel5dot10arm.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2kernel5dot10arm" {
   ami_name        = "${local.ami_name_al2kernel5dot10arm}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 arm64 ECS HVM GP2"
-  instance_type   = var.arm_instance_types[0]
+  instance_type   = var.arm_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10gpu.pkr.hcl
+++ b/al2kernel5dot10gpu.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2kernel5dot10gpu" {
   ami_name        = "${local.ami_name_al2kernel5dot10gpu}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 x86_64 ECS HVM GP2"
-  instance_type   = var.gpu_instance_types[0]
+  instance_type   = var.gpu_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/al2kernel5dot10inf.pkr.hcl
+++ b/al2kernel5dot10inf.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "al2kernel5dot10inf" {
   ami_name        = "${local.ami_name_al2kernel5dot10inf}"
   ami_description = "Amazon Linux AMI 2.0.${var.ami_version_al2} Kernel 5.10 x86_64 ECS HVM GP2"
-  instance_type   = var.inf_instance_types[0]
+  instance_type   = var.inf_instance_type
   launch_block_device_mappings {
     volume_size           = var.block_device_size_gb
     delete_on_termination = true

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -192,34 +192,34 @@ variable "ecs_init_local_override" {
   default     = ""
 }
 
-variable "general_purpose_instance_types" {
-  type        = list(string)
-  description = "List of available in-region instance types for general-purpose platform"
-  default     = ["c5.large"]
+variable "general_purpose_instance_type" {
+  type        = string
+  description = "Instance type used to build for general-purpose platform"
+  default     = "c5.large"
 }
 
-variable "gpu_instance_types" {
-  type        = list(string)
-  description = "List of available in-region instance types for GPU platform"
-  default     = ["c5.4xlarge"]
+variable "gpu_instance_type" {
+  type        = string
+  description = "Instance type used to build for GPU platform"
+  default     = "c5.4xlarge"
 }
 
-variable "arm_instance_types" {
-  type        = list(string)
-  description = "List of available in-region instance types for ARM platform"
-  default     = ["m6g.xlarge"]
+variable "arm_instance_type" {
+  type        = string
+  description = "Instance type used to build for ARM platform"
+  default     = "m6g.xlarge"
 }
 
-variable "inf_instance_types" {
-  type        = list(string)
-  description = "List of available in-region instance types for INF platform"
-  default     = ["inf1.xlarge"]
+variable "inf_instance_type" {
+  type        = string
+  description = "Instance type used to build for INF platform"
+  default     = "inf1.xlarge"
 }
 
-variable "neu_instance_types" {
-  type        = list(string)
-  description = "List of available in-region instance types for NEU platform"
-  default     = ["inf1.xlarge"]
+variable "neu_instance_type" {
+  type        = string
+  description = "Instance type used to build for NEU platform"
+  default     = "inf1.xlarge"
 }
 
 variable "ami_ou_arns" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Simplify instance type variables which are currently unnecessarily implemented as a list of strings to be strings instead. 

Currently, these lists are not iterated in any meaningful way, all have a single string element, and only the first element in the list is ever considered. Having these variables implemented as a list of strings and with their current descriptions may mislead users of these variables by giving the idea that multiple instance types can be specified and that they would be considered in some sort of meaningful way.

### Implementation details
<!-- How are the changes implemented? -->
- Update instance type variable names to be singular instead of plural
- Update instance type variable types and default values to be `string` instead of `list(string)`
- Improve accuracy of instance type variable descriptions

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Build an ECS-Optimized AMI per instance type variable. Confirm that builds succeed:
```
% REGION=us-west-2 make al2023
...
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2023: AMIs were created:
...
% REGION=ap-northeast-2 make al2kernel5dot10arm
...
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2kernel5dot10arm: AMIs were created:
...
% REGION=sa-east-1 make al2kernel5dot10gpu
...
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2kernel5dot10gpu: AMIs were created:
...
% REGION=us-east-1 make al2023neu
...
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2023neu: AMIs were created:
...
% REGION=eu-west-3 make al2inf
...
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2inf: AMIs were created:
...
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Simplify instance type vars from list(string) to string

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.