### PR TITLE
Set amazon plugin component of Packer to v1.3.9

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     amazon = {
-      version = ">= 1.2.8"
+      version = "1.3.9"
       source  = "github.com/hashicorp/amazon"
     }
   }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix Packer plugin installation failure in GitHub Actions by pinning Amazon plugin to version 1.3.9 to address HashiCorp's plugin distribution migration.
### Implementation details
<!-- How are the changes implemented? -->
Updated the Packer plugin configuration in variables.pkr.hcl to use Amazon plugin version 1.3.9, which is the last version available on GitHub releases that's compatible with Packer v1.7.4. This addresses the plugin installation failure caused by HashiCorp moving official plugin distribution from GitHub releases to releases.hashicorp.com starting with version 1.3.10.

__Additional Context:__ This is due to address static check failures in GH due to changes here [](https://discuss.hashicorp.com/t/important-update-official-packer-plugin-distribution-moving-to-releases-hashicorp-com/75972)<https://discuss.hashicorp.com/t/important-update-official-packer-plugin-distribution-moving-to-releases-hashicorp-com/75972>

<https://github.com/hashicorp/packer-plugin-amazon/releases/tag/v1.3.10>

Setting temporarily to 1.3.9 because 1.3.10 requires packer version 1.14.0 and upgrading to that requires changes to packer templates due to stricter local variable scoping rules. Version 1.3.9 is the last version that includes the required SHA256SUMS file on GitHub releases before HashiCorp moved to their own distribution system.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Verified `make static-check` passes successfully with version 1.3.9

New tests cover the changes: <!-- yes|no -->no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Set amazon plugin component of Packer to v1.3.9
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
