### PR TITLE
Pin version to 1.2.8 to unblock release

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     amazon = {
-      version = "1.3.9"
+      version = "1.2.8"
       source  = "github.com/hashicorp/amazon"
     }
   }


### PR DESCRIPTION
### Summary
Encountering issues with release due to newer packer version that needs more investigation on how we plan to migrate.

### Implementation details
Set version = 1.2.8 to match tooling versions

### Testing
Spot checked

New tests cover the changes: no 

### Description for the changelog
Pin version to 1.2.8 to unblock release

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
