### PR TITLE
Update exec SSM Agent version to 3.3.2958.0

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -108,7 +108,7 @@ variable "runc_version_al2023" {
 variable "exec_ssm_version" {
   type        = string
   description = "SSM binary version to build ECS exec support with."
-  default     = "3.3.2299.0"
+  default     = "3.3.2958.0"
 }
 
 variable "source_ami_al2" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update exec SSM Agent version to 3.3.2958.0. This version contains a change to support overriding CWLogs endpoint which is required for IPv6-only support.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran exec tests on new AL2 ARM64 and AL2023 AMD64 AMIs built with this change. They passed. 

Separately, I have verified that IPv6-only exec sessions work as expected with this SSM Agent version. 

New tests cover the changes: <!-- yes|no --> N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
enhancement: Bump exec SSM Agent version to v3.3.2958.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
