### PR TITLE
Remove hardcoded amazonaws.com in default ECS Init URL

### DIFF
--- a/scripts/install-ecs-init.sh
+++ b/scripts/install-ecs-init.sh
@@ -155,7 +155,7 @@ EOF
 if [ -z "$ECS_INIT_URL" ]; then
     ARCH=$(uname -m)
     host_suffix=$(get_default_aws_host_suffix "$REGION")
-    ECS_INIT_URL="https://s3.$REGION.amazonaws.com${host_suffix}/amazon-ecs-agent-$REGION/ecs-init-$AGENT_VERSION-$INIT_REV.$AL_NAME.$ARCH.rpm"
+    ECS_INIT_URL="https://s3.$REGION.${host_suffix}/amazon-ecs-agent-$REGION/ecs-init-$AGENT_VERSION-$INIT_REV.$AL_NAME.$ARCH.rpm"
 fi
 
 curl -fLSs -o "$WORK_DIR/ecs-init.rpm" "$ECS_INIT_URL"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Remove hardcoded "amazonaws.com" in default ECS Init URL construction logic. This is a bug fix to https://github.com/aws/amazon-ecs-ami/pull/509, and failure to address it will result in default ECS Init URL for ECS Init installation being formed improperly like the below example:
```
==> amazon-ebs.al2023: + ECS_INIT_URL=https://s3.us-west-2.amazonaws.comamazonaws.com/amazon-ecs-agent-us-west-2/ecs-init-1.97.1-1.amzn2023.x86_64.rpm
```

### Implementation details
<!-- How are the changes implemented? -->
N/A (see "Summary" section above).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Run below to build an AL2023 AMD64 ECS-Optimized AMI and verify ECS Init URL is correct:
```
% REGION=us-west-2 make al2023
...
==> amazon-ebs.al2023: + ECS_INIT_URL=https://s3.us-west-2.amazonaws.com/amazon-ecs-agent-us-west-2/ecs-init-1.97.1-1.amzn2023.x86_64.rpm
...
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2023: AMIs were created:
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
