### PR TITLE
Temporarily pin ecs-service-connect-agent package to v1.29.12.1

### DIFF
--- a/scripts/install-service-connect-appnet.sh
+++ b/scripts/install-service-connect-appnet.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -ex
 
-sudo yum install -y ecs-service-connect-agent
+# Temporarily pin to version 1.29.12.1 as latest available version 1.29.12.2 in Amazon Linux repos has a known issue.
+sudo yum install -y ecs-service-connect-agent-v1.29.12.1-*


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Temporarily pin ecs-service-connect-agent package version to 1.29.12.1. This is because latest available version 1.29.12.2 in Amazon Linux repos has a known issue.

Once a newer fixed version of ecs-service-connect-agent package is available in all AWS regions, then the temporary pinning logic should be removed.

### Implementation details
<!-- How are the changes implemented? -->
N/A (see "Summary" section above)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Build ECS-Optimized AL2023 AMI and confirm that ecs-service-connect-agent package version to 1.29.12.1 is installed. Partial output:

```
$ REGION=us-west-2 make al2023
...
    amazon-ebs.al2023: Installed:
    amazon-ebs.al2023:   ecs-service-connect-agent-v1.29.12.1-1.amzn2023.x86_64
...
==> Wait completed after 7 minutes 28 seconds

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.al2023: AMIs were created:
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Temporarily pin ecs-service-connect-agent package to v1.29.12.1

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
