### PR TITLE
Revert "Temporarily pin ecs-service-connect-agent package to v1.29.12.1"

### DIFF
--- a/scripts/install-service-connect-appnet.sh
+++ b/scripts/install-service-connect-appnet.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -ex
 
-# Temporarily pin to version 1.29.12.1 as latest available version 1.29.12.2 in Amazon Linux repos has a known issue.
-sudo yum install -y ecs-service-connect-agent-v1.29.12.1-*
+sudo yum install -y ecs-service-connect-agent


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This reverts commit 0f7ac7168c5de4610d04950610476e29dc819f2c. Last week, we temporarily pinned the service connect agent to avoid consuming a version with known issues. That issue has been mitigated, so we are good to remove this temporary pinning.

Confirmed with the service connect agent team.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
