### PR TITLE
Explicitly install nvidia-persistenced

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support-al2023.sh
+++ b/scripts/enable-ecs-agent-gpu-support-al2023.sh
@@ -22,7 +22,8 @@ sudo dnf install -y nvidia-driver \
     pciutils \
     xorg-x11-server-Xorg \
     nvidia-container-toolkit \
-    oci-add-hooks
+    oci-add-hooks \
+    nvidia-persistenced
 
 ### Package installation and setup to support P6 instances
 # Install base requirements

--- a/scripts/enable-ecs-agent-gpu-support.sh
+++ b/scripts/enable-ecs-agent-gpu-support.sh
@@ -143,7 +143,8 @@ else
         libnvidia-container1 \
         libnvidia-container-tools \
         nvidia-container-toolkit-base \
-        nvidia-container-toolkit
+        nvidia-container-toolkit \
+        nvidia-persistenced
 
     sudo yum install -y cuda-drivers \
         cuda


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR explicitly installs the `nvidia-persistenced` as part of the GPU installation scripts. Our AMI recipes have been pulling this package in as a dependency of one of the other nvidia packages. 

During today's ECS AMI builds, we see an error related to this package. We try to enable nvidia-persistenced as part of our GPU installation/setup scripts: [AL2023](https://github.com/aws/amazon-ecs-ami/blob/29ad55729644ea4334b4cfbfbeff693f56b2f2f4/scripts/enable-ecs-agent-gpu-support-al2023.sh#L44), [AL2](https://github.com/aws/amazon-ecs-ami/blob/29ad55729644ea4334b4cfbfbeff693f56b2f2f4/scripts/enable-ecs-agent-gpu-support.sh#L165)

If this is not marked as a dependency (which seems like it is the case), the `systemctl enable nvidia-persistenced` command fails, because the package was never installed.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

I am unable to repro the issue locally as I am running into a separate issue of dnf cache cleanup. Rather than trying to debug local setup, we can merge this change in and validate during the release as we try to kick one off next.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
