### PR TITLE
Install nvidia-open on the AL2023 GPU AMI

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support-al2023.sh
+++ b/scripts/enable-ecs-agent-gpu-support-al2023.sh
@@ -6,7 +6,10 @@ if [[ $AMI_TYPE != "al2023"*"gpu" ]]; then
     exit 0
 fi
 
-### Install GPU Drivers and Required Packages
+### Install GPU Drivers and Required Packages ###
+# NVIDIA installation doc: https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html#amazon-installation
+# Amazon Linux 2023 repost: https://repost.aws/articles/ARwfQMxiC-QMOgWykD9mco1w/install-nvidia-gpu-driver-cuda-toolkit-nvidia-container-toolkit-on-amazon-ec2-instances-running-amazon-linux-2023-al2023
+
 # Install base requirements
 sudo dnf install -y dkms kernel-modules-extra-$(uname -r) kernel-devel-$(uname -r)
 
@@ -17,7 +20,7 @@ sudo systemctl enable --now dkms
 sudo dnf install -y nvidia-release
 
 # Install NVIDIA drivers and tools
-sudo dnf install -y nvidia-driver \
+sudo dnf install -y nvidia-open \
     nvidia-fabric-manager \
     pciutils \
     xorg-x11-server-Xorg \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR installs the `nvidia-open` package on the ECS AL2023 GPU AMI, based on the following installation guides:
1. Nvidia: https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html#amazon-installation
2. Amazon Linux 2023: https://repost.aws/articles/ARwfQMxiC-QMOgWykD9mco1w/install-nvidia-gpu-driver-cuda-toolkit-nvidia-container-toolkit-on-amazon-ec2-instances-running-amazon-linux-2023-al2023

These docs used to recommend `nvidia-driver` but they updated the recommendation to `nvidia-open` with the most recent v580 driver series release.

### Testing

make al2023gpu

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: install nvidia-open on the AL2023 GPU AMI

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
