### PR TITLE
remove nvidia-persistenced from the installation list

### DIFF
--- a/scripts/enable-ecs-agent-gpu-support.sh
+++ b/scripts/enable-ecs-agent-gpu-support.sh
@@ -143,8 +143,7 @@ else
         libnvidia-container1 \
         libnvidia-container-tools \
         nvidia-container-toolkit-base \
-        nvidia-container-toolkit \
-        nvidia-persistenced
+        nvidia-container-toolkit
 
     sudo yum install -y cuda-drivers \
         cuda


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
In this pr https://github.com/aws/amazon-ecs-ami/pull/530, we explicitly install the `nvidia-persistenced` as part of the AL2 and AL2023 GPU installation scripts, which causing ECS AL2 GPU AMIs builds failed, so we revert it specifically for AL2 GPU build script.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
