### PR TITLE
Add optional region argument to generate-release-vars.sh

### DIFF
--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -3,10 +3,12 @@ set -eo pipefail
 
 usage() {
     echo "Usage:"
-    echo "  $0 AMI_TYPE"
-    echo "Example:"
+    echo "  $0 AMI_TYPE (REGION; optional)"
+    echo "Examples:"
     echo "  $0 al2"
+    echo "  $0 al2023 ap-northeast-2"
     echo "AMI_TYPE Must be one of: al1, al2, al2023"
+    echo "REGION (if specified) must be a valid AWS region"
 }
 
 error() {
@@ -23,8 +25,8 @@ fi
 
 readonly ami_version=$(date +"%Y%m%d")
 
-# this can be any region, as we use it to grab the latest AL2 AMI name so it should be the same across regions.
-readonly region="us-west-2"
+# Default region to us-west-2 if region is not provided.
+readonly region="${2:-us-west-2}"
 
 # Get the latest source AMI names (based on type)
 case "$ami_type" in


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add optional argument to be able to pass in region to `generate-release-vars.sh`. This does not impact any existing workflows as this argument is optional.

### Implementation details
<!-- How are the changes implemented? -->
N/A (see "Summary" section above).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Locally, revert the most recent AMI release commit (`5eee7309317b26e2bb388248b89fe49a9312e86e`) and then run the below 2 commands:
- `./generate-release-vars.sh al2`
- `./generate-release-vars.sh al2023 cn-north-1`

Verify that us-west-2 region is used in first case and that cn-north-1 region is used in second case and that release configuration files are updated accordingly.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
