### PR TITLE
Add NVIDIA kernel module loading service for AL2023 GPU AMIs

### DIFF
--- a/scripts/al2023/gpu/nvidia-kmod-load.service
+++ b/scripts/al2023/gpu/nvidia-kmod-load.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NVIDIA kernel module loader
+Before=nvidia-fabricmanager.service nvidia-persistenced.service ecs.service
+
+[Service]
+Type=oneshot
+ExecStart=/etc/ecs/nvidia-kmod-load.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/al2023/gpu/nvidia-kmod-load.sh
+++ b/scripts/al2023/gpu/nvidia-kmod-load.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+# Exit early if no NVIDIA devices are present
+if ! kmod-util has-nvidia-device; then
+  echo >&2 "no NVIDIA devices are present, not loading kernel module!"
+  exit 0
+fi
+
+readonly NVIDIA_VENDOR_ID="10de" # NVIDIA's PCI vendor ID
+readonly NVIDIA_GRID_SUBDEVICES=(
+  "27b8:1733" # L4:L4-3Q
+  "27b8:1735" # L4:L4-6Q
+  "27b8:1737" # L4:L4-12Q
+)
+readonly NVIDIA_PROPRIETARY_SUBDEVICES=(
+  "1db1:1212" # P3 instances
+  "13f2:113a" # G3 instances
+)
+
+# Helper function to check if any device matches a given array of subdevice IDs
+device-supports-module-type() {
+  local -n device_array=$1
+  local device nvidia_subdevice
+
+  for device in "${device_array[@]}"; do
+    while IFS= read -r nvidia_subdevice; do
+      if [[ "${device}" == "${nvidia_subdevice}" ]]; then
+        return 0
+      fi
+    done < <(lspci -n -mm -d "${NVIDIA_VENDOR_ID}:" | awk '{print $4":"$7}' | tr -d '"')
+  done
+
+  return 1
+}
+
+# Check if any device supports proprietary drivers (P3 and G3 instances)
+device-supports-proprietary() {
+  device-supports-module-type NVIDIA_PROPRIETARY_SUBDEVICES
+}
+
+# Check if any device supports GRID virtualization
+device-supports-grid() {
+  device-supports-module-type NVIDIA_GRID_SUBDEVICES
+}
+
+# Determine and load the appropriate NVIDIA kernel module
+main() {
+  local module_name
+
+  if device-supports-grid; then
+    module_name="nvidia-grid" # Load grid kmod
+  elif device-supports-proprietary; then
+    module_name="nvidia-proprietary" # Load proprietary kmod
+  else
+    module_name="nvidia" # Fallback to open-source kmod for all other devices
+  fi
+
+  echo "Loading NVIDIA kernel module: ${module_name}"
+  exec kmod-util load "${module_name}"
+}
+
+main "$@"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR introduces a new systemd service `nvidia-kmod-load` and a corresponding script that the service will execute at instance launch that will help instance specific kernel modules to be loaded.
### Implementation details
<!-- How are the changes implemented? -->
Introduces a new systemd oneshot service called `nvidia-kmod-load`. This service will run on instance launch and will execute the `nvidia-kmod-load.sh` script.

The `nvidia-kmod-load.sh` script will check for the sub device ID of the GPU device attached to the instance and will load the necessary kernel modules required for GPU functionality for that specific instance type. 
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Built a custom AMI and verified if the appropriate kernel modules are loaded for each instance type.

On `p3 instances`, proprietary kmods are loaded
```
sh-5.2$ dkms status
nvidia-proprietary/570.172.08, 6.1.150-174.273.amzn2023.x86_64, x86_64: installed
```

On `g6 instances`, open kmods are loaded
```
sh-5.2$ dkms status
nvidia/570.172.08, 6.1.150-174.273.amzn2023.x86_64, x86_64: installed
```

On `g6f instances`, grid kmods are loaded
```
# dkms status
nvidia-grid/570.172.08, 6.1.150-174.273.amzn2023.x86_64, x86_64: installed
```
New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add NVIDIA kernel module loading service for AL2023 GPU AMIs
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
