### PR TITLE
Update amazon-ssm-agent version for exec to 3.3.3050.0

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -96,7 +96,7 @@ variable "runc_version_al2023" {
 variable "exec_ssm_version" {
   type        = string
   description = "SSM binary version to build ECS exec support with."
-  default     = "3.3.2958.0"
+  default     = "3.3.3050.0"
 }
 
 variable "source_ami_al2" {


### PR DESCRIPTION
### Summary
This PR will bump up the amazon-ssm-agent version to 3.3.3050.0 which includes a fix for [CVE-2025-22871](https://explore.alas.aws.amazon.com/CVE-2025-22871.html) and [CVE-2025-22872](https://explore.alas.aws.amazon.com/CVE-2025-22872.html)

### Implementation details

### Testing
Built alpha AMIs on different platforms and ran our functional tests against them. 
New tests cover the changes: Not applicable

### Description for the changelog
Enhancement - Update amazon-ssm-agent version for exec to 3.3.3050.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
