### PR TITLE
Pin aws-neuronx-dkms to 2.21* on al2kernel5.10/al2023

### DIFF
--- a/scripts/enable-ecs-agent-inferentia-support.sh
+++ b/scripts/enable-ecs-agent-inferentia-support.sh
@@ -31,7 +31,9 @@ if [[ $AMI_TYPE == "al2inf" ]]; then
     # Pin the aws-neuronx-dkms package version to 2.17.17.0 only for al2inf, since the newest versions of the Neuron SDK are no longer supporting linux kernel 4.14
     sudo yum install -y aws-neuronx-dkms-2.17.17.0
 else
-    sudo yum install -y aws-neuronx-dkms-2.*
+    # Pin the aws-neuron-dkms package version to 2.21* for al2kernel5dot10inf and al2023neu
+    # Refer: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/announcements/neuron2.x/announce-eos-neuron-driver-support-inf1.html
+    sudo yum install -y aws-neuronx-dkms-2.21.*
 fi
 sudo yum install -y aws-neuronx-oci-hook-2.*
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Pin the `aws-neuronx-dkms` to `2.21*` for al2kernel5.10inf and al2023neu AMI builds. This is being done due to maintain support for all of our ECS supported EC2 instance types for AWS Neuron due to the upcoming change in the neuron drivers

> Starting with Neuron Release 2.26, Neuron driver versions above 2.21 will only support non-Inf1 instances (such as Trn1, Inf2, or other instance types). For Inf1 instance users, Neuron driver versions < 2.21 will remain supported with regular security patches.
Inf1 instance users are advised to pin the Neuron driver version to 2.21.* in their installation script.

Ref: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/announcements/neuron2.x/announce-eos-neuron-driver-support-inf1.html


### Implementation details
<!-- How are the changes implemented? -->
Pinning `aws-neuronx-dkms` to `2.21*` for `al2kernel5dot10inf` and `al2023neu` builds.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Build a test AMI and verified that the pinned package is installed

```
==> amazon-ebs.al2023neu: + sudo yum install -y 'aws-neuronx-dkms-2.21.*'
    amazon-ebs.al2023neu: Last metadata expiration check: 0:00:34 ago on Mon Oct 13 23:32:57 2025.
    amazon-ebs.al2023neu: Dependencies resolved.
    amazon-ebs.al2023neu: ================================================================================
    amazon-ebs.al2023neu:  Package             Arch      Version                     Repository      Size
    amazon-ebs.al2023neu: ================================================================================
    amazon-ebs.al2023neu: Installing:
    amazon-ebs.al2023neu:  aws-neuronx-dkms    noarch    2.21.37.0-dkms              neuron         186 k
    amazon-ebs.al2023neu: Installing dependencies:
    amazon-ebs.al2023neu:  dkms                noarch    3.2.1-182.amzn2023          amazonlinux     87 k
    amazon-ebs.al2023neu:  ed                  x86_64    1.14.2-10.amzn2023.0.2      amazonlinux     75 k
    amazon-ebs.al2023neu:  info                x86_64    6.7-10.amzn2023.0.2         amazonlinux    227 k
    amazon-ebs.al2023neu:  patch               x86_64    2.7.6-14.amzn2023.0.2       amazonlinux    129 k
    amazon-ebs.al2023neu:
    amazon-ebs.al2023neu: Transaction Summary
    amazon-ebs.al2023neu: ================================================================================
    amazon-ebs.al2023neu: Install  5 Packages
    amazon-ebs.al2023neu:
    amazon-ebs.al2023neu: Total download size: 704 k
    amazon-ebs.al2023neu: Installed size: 2.0 M
    amazon-ebs.al2023neu: Downloading Packages:
    amazon-ebs.al2023neu: (1/5): dkms-3.2.1-182.amzn2023.noarch.rpm       1.8 MB/s |  87 kB     00:00
    amazon-ebs.al2023neu: (2/5): info-6.7-10.amzn2023.0.2.x86_64.rpm      4.6 MB/s | 227 kB     00:00
    amazon-ebs.al2023neu: (3/5): ed-1.14.2-10.amzn2023.0.2.x86_64.rpm     1.4 MB/s |  75 kB     00:00
    amazon-ebs.al2023neu: (4/5): patch-2.7.6-14.amzn2023.0.2.x86_64.rpm   4.0 MB/s | 129 kB     00:00
    amazon-ebs.al2023neu: (5/5): aws-neuronx-dkms-2.21.37.0.noarch.rpm    4.3 MB/s | 186 kB     00:00
    amazon-ebs.al2023neu: --------------------------------------------------------------------------------
    amazon-ebs.al2023neu: Total                                           5.7 MB/s | 704 kB     00:00
    amazon-ebs.al2023neu: Running transaction check
    amazon-ebs.al2023neu: Waiting for process with pid 2206 to finish.
    amazon-ebs.al2023neu: Transaction check succeeded.
    amazon-ebs.al2023neu: Running transaction test
    amazon-ebs.al2023neu: Transaction test succeeded.
    amazon-ebs.al2023neu: Running transaction
    amazon-ebs.al2023neu:   Preparing        :                                                        1/1
    amazon-ebs.al2023neu:   Installing       : info-6.7-10.amzn2023.0.2.x86_64                        1/5
    amazon-ebs.al2023neu:   Installing       : ed-1.14.2-10.amzn2023.0.2.x86_64                       2/5
    amazon-ebs.al2023neu:   Installing       : patch-2.7.6-14.amzn2023.0.2.x86_64                     3/5
    amazon-ebs.al2023neu:   Installing       : dkms-3.2.1-182.amzn2023.noarch                         4/5
    amazon-ebs.al2023neu:   Running scriptlet: dkms-3.2.1-182.amzn2023.noarch                         4/5
    amazon-ebs.al2023neu: Created symlink /etc/systemd/system/multi-user.target.wants/dkms.service → /usr/lib/systemd/system/dkms.service.
    amazon-ebs.al2023neu:
    amazon-ebs.al2023neu:   Installing       : aws-neuronx-dkms-2.21.37.0-dkms.noarch                 5/5
    amazon-ebs.al2023neu:   Running scriptlet: aws-neuronx-dkms-2.21.37.0-dkms.noarch                 5/5
    amazon-ebs.al2023neu: Loading new aws-neuronx/2.21.37.0 DKMS files...
    amazon-ebs.al2023neu: Deprecated feature: CLEAN (/usr/src/aws-neuronx-2.21.37.0/dkms.conf)
    amazon-ebs.al2023neu: Deprecated feature: REMAKE_INITRD (/usr/src/aws-neuronx-2.21.37.0/dkms.conf)
    amazon-ebs.al2023neu: Building for 6.1.153-175.280.amzn2023.x86_64
    amazon-ebs.al2023neu:
    amazon-ebs.al2023neu: Building initial module aws-neuronx/2.21.37.0 for 6.1.153-175.280.amzn2023.x86_64
    amazon-ebs.al2023neu: Deprecated feature: CLEAN (/var/lib/dkms/aws-neuronx/2.21.37.0/source/dkms.conf)
    amazon-ebs.al2023neu: Deprecated feature: REMAKE_INITRD (/var/lib/dkms/aws-neuronx/2.21.37.0/source/dkms.conf)
    amazon-ebs.al2023neu: Sign command: /lib/modules/6.1.153-175.280.amzn2023.x86_64/build/scripts/sign-file
    amazon-ebs.al2023neu: Signing key: /var/lib/dkms/mok.key
    amazon-ebs.al2023neu: Public certificate (MOK): /var/lib/dkms/mok.pub
    amazon-ebs.al2023neu: Certificate or key are missing, generating self signed certificate for MOK...
    amazon-ebs.al2023neu:
    amazon-ebs.al2023neu: Building module(s)..... done.
    amazon-ebs.al2023neu: Signing module /var/lib/dkms/aws-neuronx/2.21.37.0/build/neuron.ko
    amazon-ebs.al2023neu: Deprecated feature: CLEAN (/var/lib/dkms/aws-neuronx/2.21.37.0/source/dkms.conf)
    amazon-ebs.al2023neu: Deprecated feature: REMAKE_INITRD (/var/lib/dkms/aws-neuronx/2.21.37.0/source/dkms.conf)
    amazon-ebs.al2023neu: Running the pre_install script:
    amazon-ebs.al2023neu:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    amazon-ebs.al2023neu:                                  Dload  Upload   Total   Spent    Left  Speed
    amazon-ebs.al2023neu: 100  341k  100  341k    0     0   171k      0  0:00:01  0:00:01 --:--:--  171k
    amazon-ebs.al2023neu: Done.
    amazon-ebs.al2023neu: Installing /lib/modules/6.1.153-175.280.amzn2023.x86_64/extra/neuron.ko
    amazon-ebs.al2023neu: Running the post_install script:
    amazon-ebs.al2023neu: neuron
    amazon-ebs.al2023neu: Running depmod... done.
    amazon-ebs.al2023neu: Executing post-transaction command..... done.
    amazon-ebs.al2023neu:
    amazon-ebs.al2023neu:   Verifying        : dkms-3.2.1-182.amzn2023.noarch                         1/5
    amazon-ebs.al2023neu:   Verifying        : ed-1.14.2-10.amzn2023.0.2.x86_64                       2/5
    amazon-ebs.al2023neu:   Verifying        : info-6.7-10.amzn2023.0.2.x86_64                        3/5
    amazon-ebs.al2023neu:   Verifying        : patch-2.7.6-14.amzn2023.0.2.x86_64                     4/5
    amazon-ebs.al2023neu:   Verifying        : aws-neuronx-dkms-2.21.37.0-dkms.noarch                 5/5
    amazon-ebs.al2023neu:
    amazon-ebs.al2023neu: Installed:
    amazon-ebs.al2023neu:   aws-neuronx-dkms-2.21.37.0-dkms.noarch     dkms-3.2.1-182.amzn2023.noarch
    amazon-ebs.al2023neu:   ed-1.14.2-10.amzn2023.0.2.x86_64           info-6.7-10.amzn2023.0.2.x86_64
    amazon-ebs.al2023neu:   patch-2.7.6-14.amzn2023.0.2.x86_64
    amazon-ebs.al2023neu:
    amazon-ebs.al2023neu: Complete!
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Pin aws-neuronx-dkms to 2.21* on al2kernel5.10/al2023
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
