### PR TITLE
Enable dynamic NVIDIA driver selection

### DIFF
--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -175,6 +175,16 @@ build {
     script              = "scripts/enable-ecs-agent-inferentia-support.sh"
   }
 
+  provisioner "file" {
+    sources = [
+      "scripts/al2023/gpu/kmod-util",
+      "scripts/al2023/gpu/nvidia-kmod-load.service",
+      "scripts/al2023/gpu/nvidia-kmod-load.sh"
+    ]
+    destination = "/tmp/"
+    only        = ["amazon-ebs.al2023gpu"]
+  }
+
   provisioner "shell" {
     environment_vars = [
       "AMI_TYPE=${source.name}"

--- a/scripts/al2023/gpu/install-nvidia-driver.sh
+++ b/scripts/al2023/gpu/install-nvidia-driver.sh
@@ -6,12 +6,29 @@ if [[ $AMI_TYPE != "al2023"*"gpu" ]]; then
     exit 0
 fi
 
-### Install GPU Drivers and Required Packages ###
-# NVIDIA installation doc: https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html#amazon-installation
-# Amazon Linux 2023 repost: https://repost.aws/articles/ARwfQMxiC-QMOgWykD9mco1w/install-nvidia-gpu-driver-cuda-toolkit-nvidia-container-toolkit-on-amazon-ec2-instances-running-amazon-linux-2023-al2023
+# Set executable permissions and move kmod utils to /usr/bin
+# kmod utilities are copied to /tmp by Packer
+sudo chmod +x "/tmp/kmod-util"
+sudo mv "/tmp/kmod-util" /usr/bin/
 
-# Install base requirements
-sudo dnf install -y dkms kernel-modules-extra-$(uname -r) kernel-devel-$(uname -r)
+# Configure DKMS for parallel compilation to reduce NVIDIA driver build time
+# This optimization enables multi-threaded compilation using all available CPU cores,
+sudo mkdir -p /etc/dkms
+echo "MAKE[0]=\"'make' -j$(nproc --all) modules\"" | sudo tee /etc/dkms/nvidia.conf
+
+### Base System Preparation ###
+# Install kernel development packages for current running kernel
+RUNNING_KERNEL=$(uname -r)
+sudo dnf install -y \
+  "dnf-command(versionlock)" \
+  "kernel-devel-${RUNNING_KERNEL}" \
+  "kernel-headers-${RUNNING_KERNEL}" \
+  "kernel-modules-extra-${RUNNING_KERNEL}" \
+  "kernel-modules-extra-common-${RUNNING_KERNEL}" \
+  dkms
+
+# Lock kernel version to prevent automatic updates that could break DKMS modules
+sudo dnf versionlock 'kernel*'
 
 # Enable DKMS service
 sudo systemctl enable --now dkms
@@ -19,7 +36,77 @@ sudo systemctl enable --now dkms
 # nvidia-release creates an nvidia repo file at /etc/yum.repos.d/amazonlinux-nvidia.repo
 sudo dnf install -y nvidia-release
 
-# Install NVIDIA drivers and tools
+### Kernel Module Archive Functions ###
+# These functions pre-compile and archive different NVIDIA driver variants
+# This allows runtime switching between proprietary, open-source, and GRID drivers
+# without rebuilding modules each time
+
+# Build and archive proprietary NVIDIA driver
+function archive-proprietary-kmod() {
+  sudo dnf -y install "kmod-nvidia-latest-dkms"
+
+  NVIDIA_PROPRIETARY_VERSION=$(kmod-util module-version nvidia)
+  sudo dkms remove "nvidia/$NVIDIA_PROPRIETARY_VERSION" --all
+
+  # Rename to avoid conflicts with other driver variants
+  sudo sed -i 's/PACKAGE_NAME="nvidia"/PACKAGE_NAME="nvidia-proprietary"/' /usr/src/nvidia-$NVIDIA_PROPRIETARY_VERSION/dkms.conf
+  sudo mv /usr/src/nvidia-$NVIDIA_PROPRIETARY_VERSION /usr/src/nvidia-proprietary-$NVIDIA_PROPRIETARY_VERSION
+
+  # Build and install the renamed module
+  sudo dkms add -m nvidia-proprietary -v $NVIDIA_PROPRIETARY_VERSION
+  sudo dkms build -m nvidia-proprietary -v $NVIDIA_PROPRIETARY_VERSION
+  sudo dkms install -m nvidia-proprietary -v $NVIDIA_PROPRIETARY_VERSION
+
+  # Archive for later use and clean up
+  sudo kmod-util archive nvidia-proprietary
+  sudo kmod-util remove nvidia-proprietary
+  sudo rm -rf /usr/src/nvidia-proprietary*
+  sudo dnf -y remove --all "kmod-nvidia-latest-dkms*"
+}
+
+# Build and archive open-source NVIDIA driver
+function archive-open-kmod() {
+  sudo dnf -y install "kmod-nvidia-open-dkms"
+  
+  NVIDIA_OPEN_VERSION=$(kmod-util module-version nvidia)
+  sudo kmod-util archive nvidia
+
+# Prepare source for GRID driver variant (shares same base)
+  sudo mkdir /usr/src/nvidia-grid-$NVIDIA_OPEN_VERSION
+  sudo cp -R /usr/src/nvidia-$NVIDIA_OPEN_VERSION/* /usr/src/nvidia-grid-$NVIDIA_OPEN_VERSION
+
+  sudo kmod-util remove nvidia
+}
+
+# Build and archive GRID driver
+function archive-grid-kmod() {
+  NVIDIA_OPEN_VERSION=$(ls -d /usr/src/nvidia-grid-* | sed 's/.*nvidia-grid-//')
+
+  # Rename the DKMS package to avoid conflicts with other driver variants
+  sudo sed -i 's/PACKAGE_NAME="nvidia"/PACKAGE_NAME="nvidia-grid"/g' /usr/src/nvidia-grid-$NVIDIA_OPEN_VERSION/dkms.conf
+
+  # Enable GRID-specific build flags for virtualization support
+  # Ref for build flags: https://github.com/NVIDIA/open-gpu-kernel-modules/blob/2b436058a616676ec888ef3814d1db6b2220f2eb/kernel-open/conftest.sh#L34-L35
+  sudo sed -i "s/MAKE\[0\]=\"'make'/MAKE\[0\]=\"'make' GRID_BUILD=1 GRID_BUILD_CSP=1 /g" /usr/src/nvidia-grid-$NVIDIA_OPEN_VERSION/dkms.conf
+
+  sudo dkms build -m nvidia-grid -v $NVIDIA_OPEN_VERSION
+  sudo dkms install nvidia-grid/$NVIDIA_OPEN_VERSION
+  
+  # Archive and clean up
+  sudo kmod-util archive nvidia-grid
+  sudo kmod-util remove nvidia-grid
+  sudo rm -rf /usr/src/nvidia*
+}
+
+### Build All Driver Variants ###
+# Pre-compile and archive all three driver types for runtime flexibility
+archive-proprietary-kmod
+archive-open-kmod
+archive-grid-kmod
+
+### Install GPU Drivers and Required Packages ###
+# NVIDIA installation doc: https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html#amazon-installation
+# Amazon Linux 2023 repost: https://repost.aws/articles/ARwfQMxiC-QMOgWykD9mco1w/install-nvidia-gpu-driver-cuda-toolkit-nvidia-container-toolkit-on-amazon-ec2-instances-running-amazon-linux-2023-al2023
 sudo dnf install -y nvidia-open \
     nvidia-fabric-manager \
     pciutils \
@@ -28,7 +115,11 @@ sudo dnf install -y nvidia-open \
     oci-add-hooks \
     nvidia-persistenced
 
-### Package installation and setup to support P6 instances
+# Lock NVIDIA packages to prevent automatic updates
+# Updates can break compatibility between driver and kernel modules
+sudo dnf versionlock 'nvidia*' 'kmod*' 'libnvidia*'
+
+### P6 Instance Support ###
 # Install base requirements
 sudo dnf install -y libibumad infiniband-diags nvlsm
 
@@ -38,7 +129,16 @@ sudo modprobe ib_umad
 # Ensure the ib_umad module is loaded at boot
 echo ib_umad | sudo tee /etc/modules-load.d/ib_umad.conf
 
-### Configure NVIDIA Services
+
+### Dynamic Driver Loading Setup ###
+# Install boot-time service that detects GPU hardware and loads the right driver
+# This service runs early in boot to ensure the correct driver is loaded before applications start
+sudo mv /tmp/nvidia-kmod-load.sh /etc/ecs/
+sudo mv /tmp/nvidia-kmod-load.service /etc/systemd/system/nvidia-kmod-load.service
+sudo systemctl daemon-reload
+sudo systemctl enable nvidia-kmod-load.service
+
+### NVIDIA Service Configuration ###
 # The Fabric Manager service needs to be started and enabled on EC2 P4d instances
 # in order to configure NVLinks and NVSwitches
 sudo systemctl enable nvidia-fabricmanager
@@ -46,3 +146,7 @@ sudo systemctl enable nvidia-fabricmanager
 # NVIDIA Persistence Daemon needs to be started and enabled on P5 instances
 # to maintain persistent software state in the NVIDIA driver.
 sudo systemctl enable nvidia-persistenced
+
+### Cleanup Build-Time Configuration ###
+# Remove the hardcoded DKMS configuration to prevent it from being baked into the AMI
+sudo rm -f /etc/dkms/nvidia.conf


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR completes the Dynamic NVIDIA Driver selection implementation by adding the final driver installation and archival logic to `install-nvidia-driver.sh`.
### Implementation details
<!-- How are the changes implemented? -->
This PR builds on the previous PRs that added the detection service and kmod utils. This final piece:

**Completes Driver Archival System:**
- Implements the three archival functions that pre-compile and store different NVIDIA driver variants:
  - `archive-proprietary-kmod()`: For legacy P3/G3 instances
  - `archive-open-kmod()`: Default for modern GPU instances  
  - `archive-grid-kmod()`: For instances like G6f that require GRID drivers
- All drivers compiled during AMI build

**Integrates with Detection Service:**
- Installs the `nvidia-kmod-load.service` (from previous PRs) that detects GPU hardware at boot
- Service automatically selects and loads the appropriate pre-compiled driver

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

Built a custom AMI and verified if the appropriate kernel modules are loaded for each instance type and also verified Driver-GPU functionality by running `nvidia-smi`. Ran internal tests against this custom AMI as well.

On `p3 instances`, proprietary kmods are loaded

```
sh-5.2$ dkms status
nvidia-proprietary/580.95.05, 6.1.155-176.282.amzn2023.x86_64, x86_64: installed
sh-5.2$ nvidia-smi
Wed Oct 22 20:05:54 2025
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Tesla V100-SXM2-16GB           On  |   00000000:00:1E.0 Off |                    0 |
| N/A   27C    P0             21W /  300W |       0MiB /  16384MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```

On `g6 instances`, open kmods are loaded

```
sh-5.2$ dkms status
nvidia/580.95.05, 6.1.155-176.282.amzn2023.x86_64, x86_64: installed
sh-5.2$ nvidia-smi
Wed Oct 22 20:03:18 2025
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA L4                      On  |   00000000:31:00.0 Off |                    0 |
| N/A   42C    P8             13W /   72W |       0MiB /  23034MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```

On `g6f instances`, grid kmods are loaded

```
sh-5.2$ dkms status
nvidia-grid/580.95.05, 6.1.155-176.282.amzn2023.x86_64, x86_64: installed
sh-5.2$ nvidia-smi
Wed Oct 22 20:06:06 2025
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA L4-3Q                   On  |   00000000:31:00.0 Off |                    0 |
| N/A   N/A    P0            N/A  /  N/A  |       0MiB /   3072MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enable dynamic NVIDIA driver selection
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
