### PR TITLE
README update for versionlocking in ECS AL2023 GPU AMIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ The ECS logs collector is installed during the AMI build process with the follow
 For details on the minimum IAM permissions required to build the AMI, please see the
 packer docs: https://www.packer.io/docs/builders/amazon#iam-task-or-instance-role
 
+## Version-locked packages in AL2023 ECS GPU AMIs
+
+Certain packages are critical for correct, performant behavior of GPU functionality in AL2023 ECS GPU AMIs. These include: - NVIDIA drivers (`nvidia*`) - Kernel modules (`kmod*`) - NVIDIA libraries (`libnvidia*`) - Kernel packages (`kernel*`)
+
+> [!NOTE]
+> This is not an exhaustive list. The complete list of locked packages are available with `dnf versionlock list`
+
+These packages are version-locked to ensure stability and prevent unintentional changes that could disrupt GPU workloads. As a result, these packages should generally be modified within the bounds of a managed process that gracefully handles potential issues and maintains GPU functionality.
+
+To prevent unintended modifications, the `dnf versionlock` plugin is used on these packages.
+
+If you wish to modify a locked package, you can:
+```
+# unlock a single package
+sudo dnf versionlock delete $PACKAGE_NAME 
+# unlock all packages 
+sudo dnf versionlock clear
+```
+> [!IMPORTANT]
+> When updates to these packages are necessary, customers should consider using the latest AMI version that includes the required updates. If updating existing instances is required, a careful approach involving unlocking, updating, and re-locking packages should be employed, always ensuring GPU functionality is maintained throughout the process.
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR includes a README update on information related to version locking certain packages in the ECS AL2023 GPU AMIs.
### Implementation details
<!-- How are the changes implemented? -->
README update
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
README update for versionlocking in ECS AL2023 GPU AMIs
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
