### PR TITLE
fix: prevent race condition in NVIDIA driver update detection

### DIFF
--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -97,7 +97,8 @@ Update="false"
 # Check for NVIDIA driver version updates
 gpu_update=$(./scripts/check-update-security.sh "${ami_type}_gpu")
 handle_nvidia_version "$ami_type" "$gpu_update"
-if [[ $gpu_update == true* ]]; then
+# Only trigger update if GPU update detected AND NVIDIA_DRIVER_VERSION file actually changed
+if [[ $gpu_update == true* ]] && ! git diff --quiet NVIDIA_DRIVER_VERSION; then
     Update="true"
 fi
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Previously, when the system detected an NVIDIA update and kicked off a release, it would generate a new release config. However, when a new AMI with the latest release config had not yet been released, the system would still launch the
latest available ECS AMI, detect the same NVIDIA update that was already tracked in the VERSION file, and trigger another unnecessary release with just a new date.
### Implementation details
<!-- How are the changes implemented? -->
This fix adds a git diff check to only trigger updates when the NVIDIA_DRIVER_VERSION
file actually changes, preventing duplicate releases for the same driver versions.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->no

Manual testing by hardcoding AMI ID as `AL2023_GPU_PATH="/aws/service/ecs/optimized-ami/amazon-linux-2023/gpu/al2023-ami-ecs-gpu-hvm-2023.0.20251002-kernel-6.1-x86_64-ebs"` and having AL2023 NVIDIA DRIVER VERSION as `580.95.05` which simulates that the hardcoded AMI has an older NVIDIA driver version but the version tracking file has the latest version. When script is run

```
+ '[' 0 -eq 100 ']'
+ '[' 0 -ne 0 ']'
+ echo false
+ exit 0
Update does not exist for al2023
```



### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
fix: prevent race condition in NVIDIA driver update detection
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
