### PR TITLE
AL2 AMI release 20251112

### DIFF
--- a/release-al2.auto.pkrvars.hcl
+++ b/release-al2.auto.pkrvars.hcl
@@ -1,4 +1,4 @@
-ami_version_al2               = "20251108"
+ami_version_al2               = "20251112"
 ecs_agent_version             = "1.100.1"
 ecs_init_rev                  = "1"
 docker_version                = "25.0.13"


### PR DESCRIPTION
Trigger AL2 AMI release to pick up some important security updates - https://alas.aws.amazon.com/AL2/ALAS2NITRO-ENCLAVES-2025-061.html.