### PR TITLE
Fix incorrect AMI tag behavior by making local variable names unique

### DIFF
--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -6,7 +6,7 @@ locals {
     "69-available-updates-begin",
     "71-available-updates-finish"
   ]
-  default_tags = {
+  default_tags_al2 = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
@@ -14,7 +14,7 @@ locals {
     ami_type            = "al2"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2 = merge("${local.default_tags_al2}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2" {
@@ -47,7 +47,7 @@ source "amazon-ebs" "al2" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2}"
   run_tags      = "${var.run_tags}"
 }
 

--- a/al2023arm.pkr.hcl
+++ b/al2023arm.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2023arm = "${var.ami_name_prefix_al2023}-hvm-2023.0.${var.ami_version_al2023}${var.kernel_version_al2023arm}-arm64"
-  default_tags = {
+  default_tags_al2023arm = {
     os_version          = "Amazon Linux 2023"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version_al2023}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2023arm"
     ami_version         = "2023.0.${var.ami_version_al2023}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2023arm = merge("${local.default_tags_al2023arm}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2023arm" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2023arm" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2023arm}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2023gpu.pkr.hcl
+++ b/al2023gpu.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2023gpu = "${var.ami_name_prefix_al2023}-gpu-hvm-2023.0.${var.ami_version_al2023}${var.kernel_version_al2023}-x86_64-ebs"
-  default_tags = {
+  default_tags_al2023gpu = {
     os_version          = "Amazon Linux 2023"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version_al2023}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2023gpu"
     ami_version         = "2023.0.${var.ami_version_al2023}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2023gpu = merge("${local.default_tags_al2023gpu}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2023gpu" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2023gpu" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2023gpu}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2023neu.pkr.hcl
+++ b/al2023neu.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2023neu = "${var.ami_name_prefix_al2023}-neuron-hvm-2023.0.${var.ami_version_al2023}${var.kernel_version_al2023}-x86_64"
-  default_tags = {
+  default_tags_al2023neu = {
     os_version          = "Amazon Linux 2023"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version_al2023}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2023neu"
     ami_version         = "2023.0.${var.ami_version_al2023}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2023neu = merge("${local.default_tags_al2023neu}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2023neu" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2023neu" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2023neu}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2arm = "${var.ami_name_prefix_al2}-hvm-2.0.${var.ami_version_al2}-arm64-ebs"
-  default_tags = {
+  default_tags_al2arm = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2arm"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2arm = merge("${local.default_tags_al2arm}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2arm" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2arm" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2arm}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2gpu = "${var.ami_name_prefix_al2}-gpu-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
-  default_tags = {
+  default_tags_al2gpu = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2gpu"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2gpu = merge("${local.default_tags_al2gpu}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2gpu" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2gpu" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2gpu}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2inf = "${var.ami_name_prefix_al2}-inf-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
-  default_tags = {
+  default_tags_al2inf = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2inf"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2inf = merge("${local.default_tags_al2inf}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2inf" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2inf" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2inf}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2keplergpu.pkr.hcl
+++ b/al2keplergpu.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2keplergpu = "${var.ami_name_prefix_al2}-kepler-gpu-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
-  default_tags = {
+  default_tags_al2keplergpu = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2keplergpu"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2keplergpu = merge("${local.default_tags_al2keplergpu}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2keplergpu" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2keplergpu" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2keplergpu}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2kernel5dot10.pkr.hcl
+++ b/al2kernel5dot10.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2kernel5dot10 = "${var.ami_name_prefix_al2}-kernel-5.10-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
-  default_tags = {
+  default_tags_al2kernel5dot10 = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2kernel5dot10"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2kernel5dot10 = merge("${local.default_tags_al2kernel5dot10}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2kernel5dot10" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2kernel5dot10" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2kernel5dot10}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2kernel5dot10arm.pkr.hcl
+++ b/al2kernel5dot10arm.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2kernel5dot10arm = "${var.ami_name_prefix_al2}-kernel-5.10-hvm-2.0.${var.ami_version_al2}-arm64-ebs"
-  default_tags = {
+  default_tags_al2kernel5dot10arm = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2kernel5dot10arm"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2kernel5dot10arm = merge("${local.default_tags_al2kernel5dot10arm}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2kernel5dot10arm" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2kernel5dot10arm" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2kernel5dot10arm}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2kernel5dot10gpu.pkr.hcl
+++ b/al2kernel5dot10gpu.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2kernel5dot10gpu = "${var.ami_name_prefix_al2}-kernel-5.10-gpu-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
-  default_tags = {
+  default_tags_al2kernel5dot10gpu = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2kernel5dot10gpu"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2kernel5dot10gpu = merge("${local.default_tags_al2kernel5dot10gpu}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2kernel5dot10gpu" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2kernel5dot10gpu" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2kernel5dot10gpu}"
   run_tags      = "${var.run_tags}"
 }

--- a/al2kernel5dot10inf.pkr.hcl
+++ b/al2kernel5dot10inf.pkr.hcl
@@ -1,6 +1,6 @@
 locals {
   ami_name_al2kernel5dot10inf = "${var.ami_name_prefix_al2}-kernel-5.10-inf-hvm-2.0.${var.ami_version_al2}-x86_64-ebs"
-  default_tags = {
+  default_tags_al2kernel5dot10inf = {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
@@ -8,7 +8,7 @@ locals {
     ami_type            = "al2kernel5dot10inf"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
-  merged_tags = merge("${local.default_tags}", "${var.tags}")
+  merged_tags_al2kernel5dot10inf = merge("${local.default_tags_al2kernel5dot10inf}", "${var.tags}")
 }
 
 source "amazon-ebs" "al2kernel5dot10inf" {
@@ -41,6 +41,6 @@ source "amazon-ebs" "al2kernel5dot10inf" {
   ami_users     = "${var.ami_users}"
   ssh_interface = "public_ip"
   ssh_username  = "ec2-user"
-  tags          = "${local.merged_tags}"
+  tags          = "${local.merged_tags_al2kernel5dot10inf}"
   run_tags      = "${var.run_tags}"
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR addresses https://github.com/aws/amazon-ecs-ami/issues/575 which was caused by naming collisions in local variables across all .pkr.hcl files. Every file defined identical local variable names (default_tags and merged_tags), causing Packer to apply incorrect ami_type tags when building AMIs.
### Implementation details
<!-- How are the changes implemented? -->
Renamed the local variables in all 12 affected .pkr.hcl files to be unique per variant:
- default_tags → default_tags_{variant}
- merged_tags → merged_tags_{variant}
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

Built an `al2023` AMI before the changes and observed the following incorrect tags in the console
```
Key | Value
-- | --
os_version | Amazon Linux 2
source_image_name | al2023-ami-minimal-2023.9.20251110.1-kernel-6.1-x86_64
ami_version | 2.0.20251112
ecs_runtime_version | Docker version 25.0.13
ami_type | al2kernel5dot10inf
ecs_agent_version | 1.100.1
```

Built an `al2023gpu` after making the changes and observed the following tags in the console
```
Key | Value
-- | --
ami_type | al2023
ami_version | 2023.0.20251113
ecs_agent_version | 1.100.1
ecs_runtime_version | Docker version 25.0.13
os_version | Amazon Linux 2023
source_image_name | al2023-ami-minimal-2023.9.20251110.1-kernel-6.1-x86_64
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
