### PR TITLE
Add dynamic neuron driver downgrade for al2023neu AMI on inf1 instances

### DIFF
--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -165,6 +165,18 @@ build {
     ]
   }
 
+  provisioner "file" {
+    source      = "scripts/al2023/neuron/neuron-inf1-downgrade.sh"
+    destination = "/tmp/neuron-inf1-downgrade.sh"
+    only        = ["amazon-ebs.al2023neu"]
+  }
+
+  provisioner "file" {
+    source      = "scripts/al2023/neuron/neuron-inf1-downgrade.service"
+    destination = "/tmp/neuron-inf1-downgrade.service"
+    only        = ["amazon-ebs.al2023neu"]
+  }
+
   provisioner "shell" {
     environment_vars = [
       "AMI_TYPE=${source.name}"

--- a/scripts/al2023/neuron/neuron-inf1-downgrade.service
+++ b/scripts/al2023/neuron/neuron-inf1-downgrade.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Neuron SDK downgrade for inf1 instances
+Before=cloud-init.service ecs.service
+
+[Service]
+Type=oneshot
+ExecStart=/var/lib/ecs/scripts/neuron-inf1-downgrade.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/al2023/neuron/neuron-inf1-downgrade.sh
+++ b/scripts/al2023/neuron/neuron-inf1-downgrade.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+set -e
+
+# Neuron inf1 downgrade script
+# Detects inf1 instances and downgrades neuron driver to compatible version
+
+CACHE_DIR="/opt/ecs/neuron/inf1-rpms"
+
+# Log a message to stderr (systemd provides timestamps)
+# Args: message to log
+log() {
+    echo "$*" >&2
+}
+
+# Detect inf1 hardware using PCI device IDs
+# inf1 instances have Neuron devices with IDs: 0x7064, 0x7065, 0x7066, or 0x7067
+# Returns: 0 if inf1 detected, 1 if not inf1
+detect_inf1_hardware() {
+    log "Detecting inf1 hardware via PCI devices"
+
+    # Check for inf1 Neuron device IDs
+    if lspci -n | grep -q "1d0f:\(7064\|7065\|7066\|7067\)"; then
+        log "inf1 Neuron device detected"
+        return 0
+    fi
+
+    log "No inf1 Neuron devices found"
+    return 1
+}
+
+# Downgrade neuron packages to inf1-compatible versions
+# Uses cached RPM packages and locks ALL neuron package versions to prevent updates
+# Returns 0 on success, 1 on failure
+downgrade_neuron_packages() {
+    log "Starting neuron package downgrade for inf1"
+
+    # Find all cached RPM files
+    local cached_rpms
+    cached_rpms=$(find "$CACHE_DIR" -name "*.rpm" 2>/dev/null)
+
+    if [[ -z "$cached_rpms" ]]; then
+        log "ERROR: No cached inf1-compatible packages found in $CACHE_DIR"
+        return 1
+    fi
+
+    log "Found cached packages:"
+    echo "$cached_rpms" | while read -r rpm; do
+        log "  $(basename "$rpm")"
+    done
+
+    # Process each cached RPM
+    while IFS= read -r rpm_file; do
+        [[ -n "$rpm_file" ]] || continue
+
+        # Extract package name from RPM filename
+        local package_name
+        package_name=$(rpm -qp --queryformat '%{NAME}' "$rpm_file" 2>/dev/null)
+
+        if [[ -z "$package_name" ]]; then
+            log "WARNING: Could not determine package name for $rpm_file, skipping"
+            continue
+        fi
+
+        log "Processing package: $package_name"
+
+        # Check current version
+        local current_version target_version
+        current_version=$(rpm -q "$package_name" --queryformat '%{VERSION}' 2>/dev/null || echo "none")
+        target_version=$(rpm -qp --queryformat '%{VERSION}' "$rpm_file" 2>/dev/null)
+
+        log "Current $package_name version: $current_version"
+        log "Target $package_name version: $target_version"
+
+        # Skip if already at target version
+        if [[ "$current_version" == "$target_version" ]]; then
+            log "$package_name already at target version, skipping"
+            continue
+        fi
+
+        # Remove current package
+        log "Removing current $package_name"
+        if ! rpm -e --nodeps "$package_name" 2>/dev/null; then
+            log "WARNING: Failed to remove $package_name, may not be installed"
+        fi
+
+        # Install inf1-compatible version
+        log "Installing inf1-compatible $package_name"
+        if rpm -i "$rpm_file"; then
+            log "$package_name downgrade successful"
+        else
+            log "ERROR: Failed to install inf1-compatible $package_name"
+            return 1
+        fi
+    done <<< "$cached_rpms"
+
+    # Lock all known neuron packages to prevent partial updates
+    local all_neuron_packages=("aws-neuronx-dkms" "aws-neuronx-tools" "aws-neuronx-oci-hook")
+    log "Locking all neuron packages: ${all_neuron_packages[*]}"
+    if dnf --cacheonly versionlock add "${all_neuron_packages[@]}"; then
+        log "Package version locking successful"
+    else
+        log "WARNING: Failed to lock some packages"
+    fi
+
+    log "Neuron package downgrade completed successfully"
+}
+
+# Main function - orchestrates hardware detection and conditional downgrade
+# Exit code: 0 on success, 1 on failure
+main() {
+    log "Starting neuron inf1 downgrade service"
+
+    # Detect inf1 hardware
+    if ! detect_inf1_hardware; then
+        log "Non-inf1 hardware detected, no action needed"
+        log "Neuron inf1 downgrade service completed"
+        return 0
+    fi
+
+    log "inf1 hardware detected, proceeding with downgrade"
+    if ! downgrade_neuron_packages; then
+        log "ERROR: Neuron package downgrade failed"
+        return 1
+    fi
+
+    log "Neuron inf1 downgrade service completed"
+}
+
+main "$@"

--- a/scripts/enable-ecs-agent-inferentia-support.sh
+++ b/scripts/enable-ecs-agent-inferentia-support.sh
@@ -23,6 +23,18 @@ EOF
 
 sudo mv /tmp/neuron.repo /etc/yum.repos.d/neuron.repo
 
+# Install inf1 downgrade support for al2023neu (files copied to /tmp by packer)
+if [[ $AMI_TYPE == "al2023neu" ]]; then
+    sudo dnf install -y 'dnf-command(versionlock)'
+
+    # Install downgrade script and systemd service for inf1 compatibility
+    sudo mkdir -p /var/lib/ecs/scripts/
+    sudo cp /tmp/neuron-inf1-downgrade.sh /var/lib/ecs/scripts/
+    sudo chmod +x /var/lib/ecs/scripts/neuron-inf1-downgrade.sh
+    sudo cp /tmp/neuron-inf1-downgrade.service /etc/systemd/system/
+    sudo systemctl enable neuron-inf1-downgrade.service
+fi
+
 # Install OS headers
 sudo yum install kernel-devel-$(uname -r) kernel-headers-$(uname -r) -y
 
@@ -30,10 +42,18 @@ sudo yum install kernel-devel-$(uname -r) kernel-headers-$(uname -r) -y
 if [[ $AMI_TYPE == "al2inf" ]]; then
     # Pin the aws-neuronx-dkms package version to 2.17.17.0 only for al2inf, since the newest versions of the Neuron SDK are no longer supporting linux kernel 4.14
     sudo yum install -y aws-neuronx-dkms-2.17.17.0
-else
-    # Pin the aws-neuron-dkms package version to 2.21* for al2kernel5dot10inf and al2023neu
+elif [[ $AMI_TYPE == "al2kernel5dot10inf" ]]; then
+    # Pin the aws-neuron-dkms package version to 2.21* for legacy al2kernel5dot10inf
     # Refer: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/announcements/neuron2.x/announce-eos-neuron-driver-support-inf1.html
     sudo yum install -y aws-neuronx-dkms-2.21.*
+else
+    # For al2023neu and future AMI types: prepare inf1 downgrade packages and install latest
+    sudo mkdir -p /opt/ecs/neuron/inf1-rpms
+    sudo chmod 755 /opt/ecs/neuron/inf1-rpms
+    cd /opt/ecs/neuron/inf1-rpms
+    sudo dnf download aws-neuronx-dkms-2.21.*
+    cd -
+    sudo yum install -y aws-neuronx-dkms
 fi
 sudo yum install -y aws-neuronx-oci-hook-2.*
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
AWS Neuron driver has dropped support for inf1 instance type ([see release notes](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/2.26.0/index.html#ending-support-in-2-26-0)). 

> Starting with Neuron Release 2.26, Neuron driver versions above 2.21 will only support non-Inf1 instances (such as Trn1, Inf2, or other instance types). For Inf1 instance users, Neuron driver versions less than 2.21 will remain supported with regular security patches.

So, in https://github.com/aws/amazon-ecs-ami/pull/557 we had pinned AWS Neuron Driver to version 2.21 on ECS-Optimized Neuron AMIs for AL2023 and AL2 Kernel 5.10. However, that prevents customers on non-inf1 instances from getting the latest neuron driver. This PR solves that problem for AL2023 Neuron AMI (aka `al2023neu`) by providing the latest version of the driver installed by default and a boot time service that will downgrade the driver to v2.21 if the instance type is inf1. 

### Implementation details
<!-- How are the changes implemented? -->
1. Install latest `aws-neuronx-dkms` (Neuron Driver package) on al2023neu AMI.
2. Download v2.21 of `aws-neuronx-dkms` package as an RPM file on the AMI (under `/opt/ecs/neuron/inf1-rpms`).
3. Install a boot time service named "neuron-inf1-downgrade.service" in al2023neu AMI. The service will do an idempotent downgrade of `aws-neuronx-dkms` package using the cached RPM file if the instance type is inf1. The service will be a no-op on other instance types. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
1. Tested driver version downgrade on inf1
2. Tested that `neuron-ls` and ECS containers are able to find the neuron devices on inf1. 
3. Tested that the boot time service is idempotent. 
4. Tested that the boot time service is a no-op on non-inf1 instances. 
5. Tested that non-inf1 instances get the latest Neuron Driver version. 

New tests cover the changes: <!-- yes|no --> yes (internal CI system)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Install latest aws-neuronx-dkms package on al2023neu AMI along with a boot time service to perform downgrading of the package to an inf1 compatible version if the instance type is inf1

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
