### PR TITLE
Bump containerd to 2.1.5

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -66,7 +66,7 @@ variable "docker_version" {
 variable "containerd_version" {
   type        = string
   description = "Containerd version to build AMI with."
-  default     = "2.1.4"
+  default     = "2.1.5"
 }
 
 variable "runc_version" {
@@ -84,7 +84,7 @@ variable "docker_version_al2023" {
 variable "containerd_version_al2023" {
   type        = string
   description = "Containerd version to build AL2023 AMI with."
-  default     = "2.1.4"
+  default     = "2.1.5"
 }
 
 variable "runc_version_al2023" {


### PR DESCRIPTION
### Summary
Bump containerd to 2.1.5

Addresses:
- [CVE-2025-64329](https://explore.alas.aws.amazon.com/CVE-2025-64329.html)
- [CVE-2024-25621](https://explore.alas.aws.amazon.com/CVE-2024-25621.html)

### Testing
containerd qualification was run.

AMI builds were manually run for AL2 and AL2023
- `REGION=us-west-2 make al2023`
- `REGION=us-east-1 make al2`

### Description for the changelog
Enhancement: bump containerd version to 2.1.5

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
