### PR TITLE
disable containerd's CRI plugin on ECS AL2023 AMIs

### DIFF
--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -71,6 +71,20 @@ build {
     ]
   }
 
+  provisioner "file" {
+    source      = "files/containerd-config.toml"
+    destination = "/tmp/containerd-config.toml"
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/sh -ex"
+    inline = [
+      "sudo mkdir -p /etc/containerd",
+      "sudo mv /tmp/containerd-config.toml /etc/containerd/config.toml",
+      "sudo chown root:root /etc/containerd/config.toml"
+    ]
+  }
+
   provisioner "shell" {
     script = "scripts/al2023/setup-motd.sh"
   }

--- a/files/containerd-config.toml
+++ b/files/containerd-config.toml
@@ -1,0 +1,4 @@
+version = 3
+disabled_plugins = [
+    "io.containerd.grpc.v1.cri",
+]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR disables the CRI plugin on ECS AL2023 AMIs.

The CRI plugin is an implementation of the Kubernetes container runtime interface (CRI). The cri plugin inside containerd handles all CRI service requests from the Kubelet and uses containerd internals to manage containers and container images. This is not relevant in the ECS world.

Ref: https://github.com/containerd/containerd/blob/main/docs/cri/architecture.md

This change helps us avoid CRI initialization entirely and any red-herring error logs emitted by containerd.

See: 
- https://github.com/containerd/containerd/issues/12708
- https://github.com/containerd/containerd/pull/12709

### Implementation details
<!-- How are the changes implemented? -->

Added a minimal containerd config (to disable the CRI plugin) and an installation step to the AL2023 packer recipe.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes

1. Built a test AMI and launched an AL2023 EC2 instance to verify that no CNI load errors are seen in containerd logs, and that CRI plugin load is skipped.
2. Ran ECS functional tests against the test AMI using our internal test infrastructure.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement: disable containerd's CRI plugin in ECS Optimized AL2023 AMIs.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
