### PR TITLE
Update `nvidia_driver_version_al2023` to 580.126.09

### DIFF
--- a/NVIDIA_DRIVER_VERSION
+++ b/NVIDIA_DRIVER_VERSION
@@ -13,5 +13,5 @@
 # documentation or automation scripts.
 
 nvidia_driver_version_al2 = "550.163.01"
-nvidia_driver_version_al2023 = "580.95.05"
+nvidia_driver_version_al2023 = "580.126.09"
 cuda_version_al2 = "12.4.1"


### PR DESCRIPTION
### Summary
Update `nvidia_driver_version_al2023` to 580.126.09

### Implementation details
The daily `InitiateRelease` [ran today (2/2/2026)](https://github.com/aws/amazon-ecs-ami/actions/runs/21601719403/job/62249155020) launched an EC2 instance with `ami-05b39c03a4e57a02d` (Amazon Linux AMI 2023.0.20260129 x86_64 ECS HVM EBS) and verified that no AL2023GPU updates is needed. This ami comes with NVIDIA driver `580.126.09`, which differs from the `nvidia_driver_version_al2023` in the `NVIDIA_DRIVER_VERSION` file.

This was due to a bug detailed in PR https://github.com/aws/amazon-ecs-ami/pull/618, so a one-time manual update is required.


### Testing
Launched an EC2 instance with the latest AL2023GPU AMI and ran the following
```
sh-5.2$ dnf -q --refresh check-upgrade --releasever=latest --disableplugin=versionlock nvidia-driver-cuda
sh-5.2$ echo $?
0
```

New tests cover the changes: no

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
