### PR TITLE
fix(al2023gpu): Remove dualstack URLs from nvidia repo for ISO regions

### DIFF
--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -196,7 +196,8 @@ build {
 
   provisioner "shell" {
     environment_vars = [
-      "AMI_TYPE=${source.name}"
+      "AMI_TYPE=${source.name}",
+      "AIR_GAPPED=${var.air_gapped}"
     ]
     scripts = [
       "scripts/al2023/gpu/install-nvidia-driver.sh",

--- a/scripts/al2023/gpu/install-nvidia-driver.sh
+++ b/scripts/al2023/gpu/install-nvidia-driver.sh
@@ -36,6 +36,12 @@ sudo systemctl enable --now dkms
 # nvidia-release creates an nvidia repo file at /etc/yum.repos.d/amazonlinux-nvidia.repo
 sudo dnf install -y nvidia-release
 
+# Temporary fix: ISO regions cannot use dualstack URLs, remove them from the repo file
+if [ -n "$AIR_GAPPED" ]; then
+    echo "ISO regions cannot use dualstack URLs, removing from nvidia repo"
+    sudo sed -i 's/\$dualstack//g' /etc/yum.repos.d/amazonlinux-nvidia.repo
+fi
+
 ### Kernel Module Archive Functions ###
 # These functions pre-compile and archive different NVIDIA driver variants
 # This allows runtime switching between proprietary, open-source, and GRID drivers


### PR DESCRIPTION
### Summary
Temporary fix to remove $dualstack from amazonlinux-nvidia.repo file when building in air-gapped/ISO regions, as these regions cannot use dualstack URLs.

### Implementation details
- Added `AIR_GAPPED` environment variable to the GPU provisioner in `al2023.pkr.hcl`
- Modified `install-nvidia-driver.sh` to detect ISO/air-gapped regions and remove `$dualstack` from the nvidia repo file using `sed`

### Testing
Tested building AL2023 GPU AMI in an isolated region

New tests cover the changes: no

### Description for the changelog
fix(al2023gpu): Remove dualstack URLs from nvidia repo for ISO regions to enable AL2023 GPU AMI builds in air-gapped regions