### PR TITLE
Update ECS Agent version to 1.102.0

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -48,7 +48,7 @@ variable "block_device_size_gb" {
 variable "ecs_agent_version" {
   type        = string
   description = "ECS agent version to build AMI with."
-  default     = "1.101.3"
+  default     = "1.102.0"
 }
 
 variable "ecs_init_rev" {


### PR DESCRIPTION
### Summary

Update agent version to 1.102.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
