### PR TITLE
Bump containerd to 2.2.1 for AL2023

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -84,7 +84,7 @@ variable "docker_version_al2023" {
 variable "containerd_version_al2023" {
   type        = string
   description = "Containerd version to build AL2023 AMI with."
-  default     = "2.1.5"
+  default     = "2.2.1"
 }
 
 variable "runc_version_al2023" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR bumps the containerd version from 2.1.5 to 2.2.1

### Implementation details
<!-- How are the changes implemented? -->

### Testing
Ran `REGION=us-west-2 make al2023`

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
