### PR TITLE
stop downloading open driver for AL2 4.14 and AL2 5.10 GPU AMIs in China regions

### DIFF
--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -210,7 +210,8 @@ build {
   provisioner "shell" {
     environment_vars = [
       "AMI_TYPE=${source.name}",
-      "AIR_GAPPED=${var.air_gapped}"
+      "AIR_GAPPED=${var.air_gapped}",
+      "REGION=${var.region}"
     ]
     script = "scripts/enable-ecs-agent-gpu-support.sh"
   }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Back in 2023, we had made some changes to our AL2 GPU scripts, to install open driver from Nvidia's repo, store the static tarball on the AMI, and provide a convenience script to users if they wish to use this open driver: https://github.com/aws/amazon-ecs-ami/pull/163. Specifically, this would help customers who want to use [EFA](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html).

This PR removes the above workaround, specifically for AL2 GPU AMIs in China regions. Our ECS AMI builds for release 20260225 are failing, when trying to download the open driver from Nvidia-repos, due to a cross-partition network timeout.

Here's why this is safe to do now:
- There are no active ECS users of P4/P5 instance types in China in the last 30 days.
- The convenience script is not documented in our ECS docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html. 
- To avoid/minimize customer disruption, I am only removing the workaround for China regions' AMI builds. We already do not provide this workaround in air-gapped regions. In about 3-6 months time, all ECS AL2 AMIs will reach EOL anyways.
- I launched a P4 instance with the default driver installation, and did not explicitly run the workaround script. `nvidia-smi` was successful, and able to detect the GPU - indicating the problem from 2023, no longer applies.

Note: Without the workaround script, EFA doesnt work. So customers would need to create the workaround script/tarball themselves, in China.

### Implementation details
<!-- How are the changes implemented? -->

- Updated the workaround condition to exclude China regions, in addition to air-gapped regions.
- Since this script existed in China until AMI version 20260223, I created a new stub script, that echo's a clear error and exits with exit code 1. If a customer was running this script via userdata, they will now see a meaningful error message in their cloud-init logs, instead of a vague "no such file" error.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Getting a China AWS account creds, and building an AMI locally was challenging, due to some errors unreleated to this change. Hence, I built an AMI in the us-west-2 region (`REGION=us-west-2 make al2kernel5dot10gpu`) with a modified version of this PR, such that all code paths are hit for us-west-2, instead cn. I verified the absence of open driver tarballs and that only the stub script exists.

This change will also unblock the release, and will be tested via that workflow.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement: stop downloading open driver for AL2 4.14 and AL2 5.10 GPU AMIs in China regions

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
