### PR TITLE
Revert "Release 20260508"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 - [Amazon Linux 2023 release notes](https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html)
 - [Amazon Linux 2 release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)
 
-## 20260508
-- al2023 ami version: 20260508
-
 ## 20260506
 - al2, al2023 ami version: 20260506
 - source al2 ami: amzn2-ami-minimal-hvm-2.0.20260504.0-x86_64-ebs

--- a/NVIDIA_DRIVER_VERSION
+++ b/NVIDIA_DRIVER_VERSION
@@ -12,5 +12,5 @@
 # provisioner). The pinned major version is defined in variables.pkr.hcl.
 
 nvidia_driver_version_al2 = "550.163.01"
-nvidia_driver_version_al2023 = "580.126.20"
+nvidia_driver_version_al2023 = "580.126.09"
 cuda_version_al2 = "12.4.1"

--- a/release-al2023.auto.pkrvars.hcl
+++ b/release-al2023.auto.pkrvars.hcl
@@ -1,4 +1,4 @@
-ami_version_al2023        = "20260508"
+ami_version_al2023        = "20260506"
 ecs_agent_version         = "1.103.0"
 ecs_init_rev              = "1"
 docker_version_al2023     = "25.0.14"


### PR DESCRIPTION
This reverts commit 8940c043888f330cf2f2bb6c099de458ce872dce.

Revert is necessary as release 20260508 PR was created due to NVIDIA driver version for AL2023 being erroneously flagged as needing to be updated with a version that is currently unavailable where we source NVIDIA AL2023 driver from. A separate pull request will be raised to fix the NVIDIA driver version update checking logic.