### PR TITLE
Get latest NVIDIA driver version in both AL repo and GRID bucket

### DIFF
--- a/scripts/al2023/gpu/install-nvidia-driver.sh
+++ b/scripts/al2023/gpu/install-nvidia-driver.sh
@@ -49,7 +49,8 @@ fi
 # .run file in S3, while proprietary and open come from the AL2023 nvidia repo.
 #
 # The exact driver version is determined by the security check script
-# (check-update-security.sh) as min(repo, S3 GRID) within the pinned major,
+# (check-update-security.sh) as the highest version available in BOTH the
+# AL2023 nvidia repo AND the S3 GRID bucket within the pinned major,
 # and tracked in the NVIDIA_DRIVER_VERSION file uploaded by Packer.
 
 NVIDIA_DRIVER_FULL_VERSION=$(grep "^nvidia_driver_version_al2023" /tmp/NVIDIA_DRIVER_VERSION | awk -F'"' '{print $2}')

--- a/scripts/check-update-security.sh
+++ b/scripts/check-update-security.sh
@@ -155,10 +155,10 @@ if [[ $platform == al2023* ]]; then
     if [[ $platform == *gpu ]]; then
         # dnf check-upgrade only reports the single latest version across all majors,
         # so it can't detect updates within a pinned major. Instead, query the installed
-        # version and the latest available within the pinned major, then compare locally.
+        # version and all available within the pinned major, then intersect with GRID bucket locally.
         gpu_cmd_installed="dnf repoquery --installed --arch=x86_64 --queryformat '%{version}' nvidia-driver-cuda"
-        gpu_cmd_latest="dnf repoquery --disableplugin=versionlock --arch=x86_64 --queryformat '%{version}' nvidia-driver-cuda | grep '^${pinned_major}[.]' | sort -V | tail -1"
-        command_params="commands=[\"echo INSTALLED=\$(${gpu_cmd_installed})\",\"echo LATEST=\$(${gpu_cmd_latest})\"]"
+        gpu_cmd_all="dnf repoquery --disableplugin=versionlock --arch=x86_64 --queryformat '%{version}' nvidia-driver-cuda | grep '^${pinned_major}[.]' | sort -V"
+        command_params="commands=[\"echo INSTALLED=\$(${gpu_cmd_installed})\",\"echo REPO_VERSIONS=\$(${gpu_cmd_all} | paste -sd,)\"]"
     else
         command_params="commands=[\"dnf --refresh check-upgrade --releasever=latest --disableplugin=versionlock $check_upgrade_options -q\"]"
     fi
@@ -253,35 +253,33 @@ if [ "$platform" = "al2023_gpu" ]; then
     fi
 
     installed_version=$(echo "$std_output" | grep "^INSTALLED=" | cut -d'=' -f2)
-    latest_repo_version=$(echo "$std_output" | grep "^LATEST=" | cut -d'=' -f2)
+    repo_versions_csv=$(echo "$std_output" | grep "^REPO_VERSIONS=" | cut -d'=' -f2)
 
-    if [ -z "$installed_version" ] || [ -z "$latest_repo_version" ]; then
-        echo "ERROR: Could not determine installed or latest NVIDIA driver version"
+    if [ -z "$installed_version" ] || [ -z "$repo_versions_csv" ]; then
+        echo "ERROR: Could not determine installed or available NVIDIA driver versions"
         exit 1
     fi
 
-    # Compare installed vs latest within pinned major
-    newer=$(printf '%s\n%s' "$installed_version" "$latest_repo_version" | sort -V | tail -1)
-    if [ "$newer" = "$installed_version" ]; then
-        echo "false"
-        exit 0
-    fi
-
-    # The AMI build installs min(repo, S3 GRID .run), so check the GRID bucket
-    # to determine the actual version that would be installed.
-    grid_driver_version=$(aws s3 ls --recursive s3://ec2-linux-nvidia-drivers/ --no-sign-request |
+    # Get all GRID bucket versions within pinned major
+    grid_versions=$(aws s3 ls --recursive s3://ec2-linux-nvidia-drivers/ --no-sign-request |
         grep -Eo "(NVIDIA-Linux-x86_64-)[0-9]+\.[0-9]+\.[0-9]+(-grid-aws\.run)" |
         cut -d'-' -f4 |
-        grep "^${pinned_major}\." |
-        sort -V |
-        tail -1)
-    if [ -z "$grid_driver_version" ]; then
-        echo "ERROR: Could not determine NVIDIA GRID driver version from S3 for major ${pinned_major}"
+        grep "^${pinned_major}\.")
+    if [ -z "$grid_versions" ]; then
+        echo "ERROR: Could not determine NVIDIA GRID driver versions from S3 for major ${pinned_major}"
         exit 1
     fi
 
-    # Use min(repo, GRID) as the effective version, same as the install script
-    effective_version=$(printf '%s\n%s' "$latest_repo_version" "$grid_driver_version" | sort -V | head -1)
+    # Find intersection: keep only repo versions that also exist in the GRID bucket,
+    # then pick the latest version as the effective version
+    effective_version=$(echo "$repo_versions_csv" | tr ',' '\n' | grep -v '^$' |
+        grep -xF -f <(echo "$grid_versions") |
+        sort -V | tail -1)
+
+    if [ -z "$effective_version" ]; then
+        echo "ERROR: No common NVIDIA driver version found between repo and GRID bucket for major ${pinned_major}"
+        exit 1
+    fi
 
     # Only trigger a release if the effective version is newer than installed
     newer=$(printf '%s\n%s' "$installed_version" "$effective_version" | sort -V | tail -1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Get latest NVIDIA driver version that exists in both the AL repo and GRID bucket.

This is necessary because AL repo could have versions of the NVIDIA driver that the GRID bucket does not have, and vice versa.

### Implementation details
<!-- How are the changes implemented? -->
When checking for NVIDIA driver updates:
- get all available versions within the pinned major from the AL repo
- get all available versions within the pinned major from the GRID bucket
- find the intersection (i.e., keep only AL repo versions that also exist in the GRID bucket)
- pick the latest version from the intersection and set that as the effective version needed

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Tested the version selection logic locally and forced AL repo versions returned to be `[580.65.06, 580.82.07, 580.95.05, 580.105.08, 580.126.20]` while forcing the GRID bucket versions returned to be `[580.65.06, 580.82.07, 580.95.05, 580.105.08, 580.126.09, 580.159.03]`.

Validated that `580.126.20` (only present in AL repo versions and NOT in GRID bucket versions) is excluded and the effective version resolves to `580.105.08` (i.e., the highest version present in both the AL repo versions and GRID bucket versions).

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: feature, enhancement, bugfix, housekeeping

Examples:
- feature - Enable dynamic NVIDIA driver selection
- enhancement - Bump docker version to x.x.x
- bugfix - remove nvidia-persistenced from the installation list
- housekeeping - Fix bug in nvidia driver upgrade check command

Note: A PR check will fail if this section does not contain a changelog with a valid category keyword.

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
housekeeping - Get latest NVIDIA driver version in both AL repo and GRID bucket

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
