### PR TITLE
Fix generate-changelog adding unchanged AL family

### DIFF
--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -60,15 +60,20 @@ read_old_values() {
     fi
 }
 
-# Detect which AMI types were updated
+# Returns 0 (true) if the given file has staged changes
+has_staged_changes() {
+    ! git diff --cached --quiet -- "$1" 2>/dev/null
+}
+
+# Detect which AMI types were updated by checking what's staged in git
 detect_updates() {
     al2_updated="false"
     al2023_updated="false"
 
-    if [ -n "$new_ami_version_al2" ] && [ "$new_ami_version_al2" != "$old_ami_version_al2" ]; then
+    if has_staged_changes release-al2.auto.pkrvars.hcl; then
         al2_updated="true"
     fi
-    if [ -n "$new_ami_version_al2023" ] && [ "$new_ami_version_al2023" != "$old_ami_version_al2023" ]; then
+    if has_staged_changes release-al2023.auto.pkrvars.hcl; then
         al2023_updated="true"
     fi
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
For context, the `generate-changelog.sh` script currently checks which platforms were updated by comparing file contents on disk. However, `generate-release-vars.sh` always rewrites `ami_version` to today's date in both release files (AL2 and AL2023), regardless of whether an actual update exists for that platform. This makes both files always look "changed" on disk, even when `check-update.sh` only staged one of them. This can result in CHANGELOG update incorrectly indicating that an unchanged AL family has a new AMI version.

This pull request updates generate CHANGELOG workflow to only consider staged files (i.e., files that have had `git add` run for them) when determining whether or not to surface that an update has been detected for a given AL family.

### Implementation details
<!-- How are the changes implemented? -->
Use `git diff --cached` to check if file was actually staged and use that as the source of truth for whether an update is detected.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Tested the `detect_updates` logic locally by simulating four scenarios: by making trivial edits to both the AL2 and AL2023 release files then selectively running `git add` for them to create the staged/unstaged conditions: 
1. only AL2023 staged
2. only AL2 staged
3. both AL2 and AL2023 staged
4. neither AL2 nor AL2023 staged

Validated that in all of the above scenarios, the function correctly reported only the applicable AL families with staged changes as having updates (i.e., updates are no longer falsely detected based on file contents on disk alone).

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: feature, enhancement, bugfix, housekeeping

Examples:
- feature - Enable dynamic NVIDIA driver selection
- enhancement - Bump docker version to x.x.x
- bugfix - remove nvidia-persistenced from the installation list
- housekeeping - Fix bug in nvidia driver upgrade check command

Note: A PR check will fail if this section does not contain a changelog with a valid category keyword.

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
housekeeping - Fix generate-changelog adding unchanged AL family

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
