### PR TITLE
Add --releasever=latest to gpu_cmd_all dnf repoquery for AL2023 GPU driver check

### DIFF
--- a/scripts/check-update-security.sh
+++ b/scripts/check-update-security.sh
@@ -157,7 +157,7 @@ if [[ $platform == al2023* ]]; then
         # so it can't detect updates within a pinned major. Instead, query the installed
         # version and all available within the pinned major, then intersect with GRID bucket locally.
         gpu_cmd_installed="dnf repoquery --installed --arch=x86_64 --queryformat '%{version}' nvidia-driver-cuda"
-        gpu_cmd_all="dnf repoquery --disableplugin=versionlock --arch=x86_64 --queryformat '%{version}' nvidia-driver-cuda | grep '^${pinned_major}[.]' | sort -V"
+        gpu_cmd_all="dnf repoquery --releasever=latest --disableplugin=versionlock --arch=x86_64 --queryformat '%{version}' nvidia-driver-cuda | grep '^${pinned_major}[.]' | sort -V"
         command_params="commands=[\"echo INSTALLED=\$(${gpu_cmd_installed})\",\"echo REPO_VERSIONS=\$(${gpu_cmd_all} | paste -sd,)\"]"
     else
         command_params="commands=[\"dnf --refresh check-upgrade --releasever=latest --disableplugin=versionlock $check_upgrade_options -q\"]"


### PR DESCRIPTION
### Summary
The `gpu_cmd_all` check in `check-update-security.sh` uses `dnf repoquery` to detect available NVIDIA driver updates. Without `--releasever=latest`, dnf resolves against an older/default release version and misses available updates.

### Implementation details
Add `--releasever=latest` to `gpu_cmd_all` check in `check-update-security.sh`


### Testing
Before: No updates seen in file `NVIDIA_DRIVER_VERSION` -  https://github.com/aws/amazon-ecs-ami/pull/697/changes
After: Updates seen in file [`NVIDIA_DRIVER_VERSION`](https://github.com/aws/amazon-ecs-ami/pull/699/changes#diff-8ae251acb25407ed5d628d1b8136a0e927c6f6ae25a403a7ebd09c981d7c2b56)

New tests cover the changes: no

### Description for the changelog
housekeeping - add `--releasever=latest` to `gpu_cmd_all` dnf repoquery for AL2023 GPU driver check

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
