### PR TITLE
upgrade ssm exec vers to 3.3.4624.0

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -95,7 +95,7 @@ variable "runc_version_al2023" {
 
 variable "exec_ssm_version" {
   type        = string
-  default     = "3.3.4108.0"
+  default     = "3.3.4624.0"
   description = "SSM binary version to build ECS exec support with."
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR upgrades the ssm exec version to 3.3.4624.0 to resolve instances having a CVE-2026-46595 vulnerability, this has been fixed recently in the ssm agent repo.

### Implementation details
Update exec_ssm_version in variables.pkr.hcl

### Testing
Built al2023
<img width="1889" height="802" alt="image" src="https://github.com/user-attachments/assets/0cfedb29-4eab-4f4f-981f-3f5d0ebaa6db" />


New tests cover the changes: no

### Description for the changelog
enhancement - Bump ssm exec version to 3.3.4624.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
