### PR TITLE
Fix flaky al2023neu AMI build: add post-reboot barrier before neuron upload

### DIFF
--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -169,6 +169,16 @@ build {
     ]
   }
 
+  ### Reboot barrier: wait until the rebooted instance is reachable before
+  ### running any provisioner below, so none of them reuse the dying pre-reboot session.
+  provisioner "shell" {
+    pause_before        = "30s"
+    start_retry_timeout = "5m"
+    inline = [
+      "echo 'instance back up after reboot:' && uptime"
+    ]
+  }
+
   provisioner "file" {
     sources = [
       "scripts/al2023/neuron/neuron-inf1-downgrade.sh",


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
Fixes a flaky `al2023neu` AMI build.  

After the instance reboots, provisioners that run afterward could reuse the dying pre-reboot SSH session, causing intermittent failures when uploading/installing the neuron packages.  For example, Packer uses the still-alive pre-reboot SSH session and uploads to `/tmp`. The reboot then wipes `/tmp`, so the subsequent `enable-ecs-agent-inferentia-support.sh` fails when it tries to `cp /tmp/neuron-inf1-downgrade.sh`. 

This PR adds a reboot barrier that waits until the rebooted instance is reachable before any subsequent provisioner runs.

### Implementation details
<!-- How are the changes implemented? -->
Adds a `shell` provisioner immediately after the reboot step in `al2023.pkr.hcl`:
- `pause_before = "30s"` gives the instance time to begin rebooting.
- `start_retry_timeout = "5m"` retries the connection until SSH is back up.
- The inline command (`echo 'instance back up after reboot:' && uptime`) is a no-op that simply forces Packer to establish a fresh post-reboot session before the neuron `file` provisioner runs.

This guarantees later provisioners do not reuse the pre-reboot session.

### Testing
<!-- How was this tested? -->
Ran the `al2023neu` AMI build successfully and found `instance back up after reboot` in the logs.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
bugfix - Add post-reboot barrier in al2023neu build to prevent reuse of the pre-reboot session before neuron upload

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
