### PR TITLE
fix: skip missing authorized_keys cleanup paths

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -75,7 +75,7 @@ cleanup "${SSH_FILES[@]}"
 USERS=$(ls /home/)
 for user in $USERS; do
     echo Deleting /home/"$user"/.ssh/authorized_keys
-    sudo find /home/"$user"/.ssh/authorized_keys -type f -exec shred -zuf {} \;
+    sudo find /home/"$user" -maxdepth 2 -path /home/"$user"/.ssh/authorized_keys -type f -exec shred -zuf {} \;
 done
 for user in $USERS; do
     if sudo test -f /home/"$user"/.ssh/authorized_keys; then


### PR DESCRIPTION
Closes #709.

This updates the per-user `authorized_keys` cleanup so the `find` command starts at the user home directory and filters to `.ssh/authorized_keys`, instead of using the file itself as the `find` starting path. When a user does not have that file, `find` now exits successfully with no matches instead of failing the whole cleanup script under `set -e`.

The follow-up verification loop is unchanged, so the script still fails if an `authorized_keys` file remains after cleanup.

Testing:
- `bash -n scripts/cleanup.sh`
- `git diff --check`
- temporary `find` smoke check with `set -e` for both missing and present `.ssh/authorized_keys`
