### PR TITLE
Update Docker to 25.0.16 and containerd to 2.2.4

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -60,7 +60,7 @@ variable "ecs_init_rev" {
 variable "docker_version" {
   type        = string
   description = "Docker version to build AMI with."
-  default     = "25.0.14"
+  default     = "25.0.16"
 }
 
 variable "containerd_version" {
@@ -78,13 +78,13 @@ variable "runc_version" {
 variable "docker_version_al2023" {
   type        = string
   description = "Docker version to build AL2023 AMI with."
-  default     = "25.0.14"
+  default     = "25.0.16"
 }
 
 variable "containerd_version_al2023" {
   type        = string
   description = "Containerd version to build AL2023 AMI with."
-  default     = "2.2.3"
+  default     = "2.2.4"
 }
 
 variable "runc_version_al2023" {


### PR DESCRIPTION
Update Docker to 25.0.16 and containerd to 2.2.4


### Description for the changelog

enhancement - Bump docker version to 25.0.16, containerd to 2.2.4

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
