### PR TITLE
Add xorg* to version-locked packages

### DIFF
--- a/scripts/al2023/gpu/install-nvidia-driver.sh
+++ b/scripts/al2023/gpu/install-nvidia-driver.sh
@@ -189,7 +189,7 @@ sudo dnf install -y \
 
 # Lock NVIDIA packages to prevent automatic updates
 # Updates can break compatibility between driver and kernel modules
-sudo dnf versionlock 'nvidia*' 'kmod*' 'libnvidia*'
+sudo dnf versionlock 'nvidia*' 'kmod*' 'libnvidia*' 'xorg*'
 
 # Ensure gridd.conf exists for the nvidia-gridd service when it starts up
 sudo mkdir -p /etc/nvidia


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add `xorg*` to the list of version locked packages
### Implementation details
<!-- How are the changes implemented? -->
Added `xorg*` to the `dnf versionlock` command
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Built a test ECS AL2023 GPU AMI with the change and ran the following commands
```
sh-5.2$ dnf versionlock list | grep xorg
xorg-x11-drv-libinput-0:1.4.0-2.amzn2023.0.1.*
xorg-x11-server-common-0:21.1.13-5.amzn2023.0.10.*
xorg-x11-nvidia-3:580.159.03-1.amzn2023.*
xorg-x11-server-Xorg-0:21.1.13-5.amzn2023.0.10.*
```
New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: feature, enhancement, bugfix, housekeeping

Examples:
- feature - Enable dynamic NVIDIA driver selection
- enhancement - Bump docker version to x.x.x
- bugfix - remove nvidia-persistenced from the installation list
- housekeeping - Fix bug in nvidia driver upgrade check command

Note: A PR check will fail if this section does not contain a changelog with a valid category keyword.

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
bugfix - Add xorg* to version-locked packages
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
