### PR TITLE
Tolerate missing authorized_keys during cleanup

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -74,8 +74,11 @@ echo "Cleaning up ssh files"
 cleanup "${SSH_FILES[@]}"
 USERS=$(ls /home/)
 for user in $USERS; do
-    echo Deleting /home/"$user"/.ssh/authorized_keys
-    sudo find /home/"$user"/.ssh/authorized_keys -type f -exec shred -zuf {} \;
+    authorized_keys_file=/home/"$user"/.ssh/authorized_keys
+    echo Deleting "$authorized_keys_file"
+    if sudo test -f "$authorized_keys_file"; then
+        sudo find "$authorized_keys_file" -type f -exec shred -zuf {} \;
+    fi
 done
 for user in $USERS; do
     if sudo test -f /home/"$user"/.ssh/authorized_keys; then


### PR DESCRIPTION
Fixes #709.

`cleanup.sh` currently calls `find` with each user's `authorized_keys` path as the starting point. If that file is already missing, `find` exits with an error even though the script is trying to remove that file.

This checks that the file exists before calling `find`, keeping the cleanup targeted to the same path while tolerating users that do not have an `authorized_keys` file.

Checked with `git diff --check` and `bash -n scripts/cleanup.sh`.

### Description for the changelog

bugfix - Tolerate missing authorized_keys during cleanup

