### PR TITLE
InitiateRelease workflow: Use non-GPU instance for AL2023 GPU update check

### DIFF
--- a/scripts/check-update-security.sh
+++ b/scripts/check-update-security.sh
@@ -81,7 +81,9 @@ case "$platform" in
     ;;
 "al2023_gpu")
     ami_path=$AL2023_GPU_PATH
-    instance_type="g5.xlarge"
+    # Keep the default non-GPU instance type. The update check only runs dnf
+    # repoquery against the NVIDIA repo (baked into the GPU AMI and enabled by
+    # default) and the local RPM DB, so no GPU hardware is required.
     ;;
 *)
     error_msg "Incorrect platform selection"


### PR DESCRIPTION
### Summary
  Run the `al2023_gpu` security/update check on the default non-GPU `c5.large` instance instead of forcing a `g5.xlarge`, to stop `InitiateRelease` from failing on transient GPU capacity shortages.
  
  ### Implementation details

Updated `scripts/check-update-security.sh`: Removed the instance type override so the AL2023 GPU update checks use the default `c5.large` (x86_64), matching how `al2_gpu` has always run.
  
  ### Testing
  Launched a `c5.large` from the AL2023 ECS GPU AMI (`ami-0493eb761065b94d7`,
  us-west-2) and ran the exact check commands over SSM:
  - `dnf repoquery --installed ... nvidia-driver-cuda` → `580.159.03` (RPM DB readable, no GPU).
  - `dnf repoquery --releasever=latest ... | grep '^580[.]' | sort -V` → hit the
    "Amazon Linux 2023 NVIDIA repository" and returned the full `580.*` list
    (no GPU, no manual `--enablerepo`).
  
  Confirmed the downstream logic is unchanged: the effective version is the
  latest present in both the repo and the GRID S3 bucket, and it is still
  compared against the installed version to decide whether to trigger a release.
  `bash -n scripts/check-update-security.sh` passes.
  
  New tests cover the changes: no
  
  ### Description for the changelog
  Housekeeping - Run al2023_gpu update check on a non-GPU instance to avoid InsufficientInstanceCapacity issues
  
  ### Licensing
  
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.