### PR TITLE
fix: Make cleanup.sh robust to missing user .ssh/authorized_keys files

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -75,7 +75,7 @@ cleanup "${SSH_FILES[@]}"
 USERS=$(ls /home/)
 for user in $USERS; do
     echo Deleting /home/"$user"/.ssh/authorized_keys
-    sudo find /home/"$user"/.ssh/authorized_keys -type f -exec shred -zuf {} \;
+    sudo find /home -maxdepth 4 -path /home/"$user"/.ssh/authorized_keys -type f -exec shred -zuf {} \;
 done
 for user in $USERS; do
     if sudo test -f /home/"$user"/.ssh/authorized_keys; then


### PR DESCRIPTION
Fixes #709. This modifies the find command in `cleanup.sh` to start from `/home` so that it does not crash if a user does not have an `.ssh/authorized_keys` file.