### PR TITLE
Add nvidia-mps-service to AL2023 GPU AMIs

### DIFF
--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -204,7 +204,8 @@ build {
       "scripts/al2023/gpu/nvidia-kmod-load.service",
       "scripts/al2023/gpu/nvidia-kmod-load.sh",
       "scripts/al2023/gpu/set-nvidia-clocks",
-      "scripts/al2023/gpu/set-nvidia-clocks.service"
+      "scripts/al2023/gpu/set-nvidia-clocks.service",
+      "scripts/al2023/gpu/nvidia-mps.service"
     ]
     destination = "/tmp/"
     only        = ["amazon-ebs.al2023gpu"]

--- a/scripts/al2023/gpu/install-nvidia-driver.sh
+++ b/scripts/al2023/gpu/install-nvidia-driver.sh
@@ -220,9 +220,15 @@ sudo chmod +x /tmp/set-nvidia-clocks
 sudo mv /tmp/set-nvidia-clocks /usr/bin/set-nvidia-clocks
 sudo mv /tmp/set-nvidia-clocks.service /etc/systemd/system/set-nvidia-clocks.service
 
+### NVIDIA MPS Control Daemon Setup ###
+# Start the NVIDIA MPS control daemon at boot so containers can 
+# utilize MPS for GPU sharing
+sudo mv /tmp/nvidia-mps.service /etc/systemd/system/nvidia-mps.service
+
 sudo systemctl daemon-reload
 sudo systemctl enable nvidia-kmod-load.service
 sudo systemctl enable set-nvidia-clocks.service
+sudo systemctl enable nvidia-mps.service
 
 ### NVIDIA Service Configuration ###
 # The Fabric Manager service needs to be started and enabled on EC2 P4d instances

--- a/scripts/al2023/gpu/nvidia-mps.service
+++ b/scripts/al2023/gpu/nvidia-mps.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=NVIDIA MPS Control Daemon
+Documentation=https://docs.nvidia.com/deploy/mps/
+Wants=nvidia-kmod-load.service
+After=nvidia-kmod-load.service
+Before=ecs.service
+ConditionPathExists=/usr/bin/nvidia-cuda-mps-control
+
+[Service]
+Type=exec
+ExecStart=/usr/bin/nvidia-cuda-mps-control -f -multiuser-server
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds an NVIDIA MPS (Multi-Process Service) control daemon to the AL2023 GPU AMI so multiple containers can share a single physical GPU under enforced per-container limits. The daemon is provisioned as a systemd service, started at boot, and ordered before the ECS agent so it is serving before any MPS task is placed.
### Implementation details
<!-- How are the changes implemented? -->
- New unit scripts `/al2023/gpu/nvidia-mps.service` which runs `/usr/bin/nvidia-cuda-mps-control -f -multiuser-server` as root. `Type=exec` (long-running, foreground -f so systemd supervises the real process) with `Restart=always` /and `RestartSec=1`. Ordered `After=nvidia-kmod-load.service` (driver-readiness) and `Before=ecs.service`. `WantedBy=multi-user.target`. `ConditionPathExists=/usr/bin/nvidia-cuda-mps-control` so the unit no-ops cleanly if the MPS binary is absent. `-multiuser-server` is required because colocated ECS containers can run as different UIDs.
- `al2023.pkr.hcl` - adds the unit to the GPU file-provisioner sources list so it is staged to `/tmp` during the build.
- `scripts/al2023/gpu/install-nvidia-driver.sh` - moves the unit into `/etc/systemd/system/` and runs `systemctl enable nvidia-mps.service`, alongside the existing GPU units.
### Testing
<!-- How was this tested? -->
Built the AL2023 GPU AMI and launched a g4dn.xlarge. Verified:

- Boot: unit installed, enabled, and active, running as root with the expected -f -multiuser-server flags. Control socket created at `/tmp/nvidia-mps/`.
- Ordering: daemon reached active ~10s before ecs.service. Before=ecs.service and After=nvidia-kmod-load.service confirmed.
- Functional: get_server_list exits 0, daemon is serving.
- Crash/restart: SIGTERM and SIGKILL each restart within ~1s; 5 rapid kills never drive the unit to failed. 
- Isolation: ecs.service and docker remain active throughout daemon churn.
- Tested MPS workloads on daemon and they run as intended.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: feature, enhancement, bugfix, housekeeping

Examples:
- feature - Enable dynamic NVIDIA driver selection
- enhancement - Bump docker version to x.x.x
- bugfix - remove nvidia-persistenced from the installation list
- housekeeping - Fix bug in nvidia driver upgrade check command

Note: A PR check will fail if this section does not contain a changelog with a valid category keyword.

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
feature - Add nvidia-mps-service to AL2023 GPU AMIs
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
