### PR TITLE
Rotate nv-hostengine logs for AL2023 GPU AMIs

### DIFF
--- a/scripts/al2023/gpu/install-dcgm.sh
+++ b/scripts/al2023/gpu/install-dcgm.sh
@@ -31,8 +31,9 @@ After=nvidia-persistenced.service
 Wants=nvidia-persistenced.service
 
 [Service]
+ExecStartPre=/usr/bin/mkdir -p /var/log/ecs
 ExecStart=
-ExecStart=/usr/bin/nv-hostengine -n --service-account nvidia-dcgm --domain-socket /run/nvidia-dcgm/nv-hostengine
+ExecStart=/usr/bin/nv-hostengine -n --service-account nvidia-dcgm --domain-socket /run/nvidia-dcgm/nv-hostengine -f /var/log/ecs/nv-hostengine.log
 RuntimeDirectory=nvidia-dcgm
 RuntimeDirectoryMode=0755
 EOF
@@ -40,7 +41,7 @@ sudo systemctl daemon-reload
 
 ### Configure log rotation for DCGM logs
 sudo tee /etc/logrotate.d/nv-hostengine <<'EOF'
-/var/log/nv-hostengine.log {
+/var/log/ecs/nv-hostengine.log {
     size 5M
     rotate 1
     missingok

--- a/scripts/al2023/gpu/install-dcgm.sh
+++ b/scripts/al2023/gpu/install-dcgm.sh
@@ -38,6 +38,17 @@ RuntimeDirectoryMode=0755
 EOF
 sudo systemctl daemon-reload
 
+### Configure log rotation for DCGM logs
+sudo tee /etc/logrotate.d/nv-hostengine <<'EOF'
+/var/log/nv-hostengine.log {
+    size 5M
+    rotate 1
+    missingok
+    notifempty
+    copytruncate
+}
+EOF
+
 ### Enable DCGM and dcgm-init services
 sudo systemctl enable nvidia-dcgm
 sudo systemctl enable dcgm-init


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Mirrors the logrotate config added for nvidia-container-runtime in PR #541. Prevents /var/log/ecs/nv-hostengine.log from growing unbounded on long-running GPU instances.

People have reported huge logs here: https://github.com/NVIDIA/gpu-monitoring-tools/issues/182. One person reported `nv-hostengine.log` having 8+ GB of data. 

### Implementation details
<!-- How are the changes implemented? -->

Modified: `scripts/al2023/gpu/install-dcgm.sh` to rotate `nv-hostengine.log`. 

The logs by default are located in `/var/log/nv-hostengine.log` but we redirect them to `/var/log/ecs/nv-hostengine.log` via the `-f` flag: https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/debugging-and-troubleshooting.html#enable-logging-using-standalone-hostengine

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Manual testing conducted to confirm that `nv-hostengine.log` exists and that the log size does not exceed 5 MB. 

Build a custom GPU AMI with DCGM package and `nv-hostengine` installed and checked that logs were being emitted. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: feature, enhancement, bugfix, housekeeping

Examples:
- feature - Enable dynamic NVIDIA driver selection
- enhancement - Bump docker version to x.x.x
- bugfix - remove nvidia-persistenced from the installation list
- housekeeping - Fix bug in nvidia driver upgrade check command

Note: A PR check will fail if this section does not contain a changelog with a valid category keyword.

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - Rotate nv-hostengine logs for AL2023 GPU AMIs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
