### PR TITLE
Update AL2 MOTD with latest AL2/AL2023 support info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ECS-optimized AMI Build Recipes
 > [!IMPORTANT]
 > The ECS-optimized Amazon Linux 1 AMI (AL1) has reached its end-of-life (EOL) on September 15, 2025.
-> The ECS-optimized Amazon Linux 2 AMI (AL2) will reach its EOL on June 30, 2026, mirroring the same EOL date of the upstream [Amazon Linux 2 Operating System](https://aws.amazon.com/amazon-linux-2/faqs).
-> We encourage customers to upgrade their applications to use Amazon Linux 2023, which includes long term support through 2028.
+> The ECS-optimized Amazon Linux 2 AMI (AL2) has reached its EOL on June 30, 2026, mirroring the same EOL date of the upstream [Amazon Linux 2 Operating System](https://aws.amazon.com/amazon-linux-2/faqs).
+> We encourage customers to upgrade their applications to use Amazon Linux 2023, which includes long term support [through 2029](https://docs.aws.amazon.com/linux/al2023/release-notes/support-info-by-support-statement.html#support-info-by-support-statement-eol).
 
 This is a [packer](https://packer.io) recipe for creating an ECS-optimized AMI.
 It will create a private AMI in whatever account you are running it in.
@@ -73,11 +73,11 @@ packer docs: https://www.packer.io/docs/builders/amazon#iam-task-or-instance-rol
 
 ## Version-locked packages in AL2023 ECS GPU AMIs
 
-Certain packages are critical for correct, performant behavior of GPU functionality in AL2023 ECS GPU AMIs. These include: 
+Certain packages are critical for correct, performant behavior of GPU functionality in AL2023 ECS GPU AMIs. These include:
 
-- NVIDIA drivers (`nvidia*`) 
-- Kernel modules (`kmod*`) 
-- NVIDIA libraries (`libnvidia*`) 
+- NVIDIA drivers (`nvidia*`)
+- Kernel modules (`kmod*`)
+- NVIDIA libraries (`libnvidia*`)
 - Kernel packages (`kernel*`)
 - Xorg server packages (`xorg*`)
 - DCGM library (`datacenter-gpu-manager-*`)
@@ -92,8 +92,8 @@ To prevent unintended modifications, the `dnf versionlock` plugin is used on the
 If you wish to modify a locked package, you can:
 ```
 # unlock a single package
-sudo dnf versionlock delete $PACKAGE_NAME 
-# unlock all packages 
+sudo dnf versionlock delete $PACKAGE_NAME
+# unlock all packages
 sudo dnf versionlock clear
 ```
 > [!IMPORTANT]

--- a/files/29-ecs-banner-begin.sh.amzn2
+++ b/files/29-ecs-banner-begin.sh.amzn2
@@ -20,11 +20,12 @@ echo -e "
    _|  (   \__ \   Amazon Linux 2 (ECS Optimized)
  ____|\___|____/
 
-AL2 End of Life is 2026-06-30.
+AL2 End of Life was 2026-06-30.
 
 A newer version of Amazon Linux is available!
 
-Amazon Linux 2023, GA and supported until 2028-03-15.
+Amazon Linux 2023, GA and supported until 2029-06-30.
+  https://docs.aws.amazon.com/linux/al2023/release-notes/support-info-by-support-statement.html#support-info-by-support-statement-eol
   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI"
 
 # Disable system-release banner during update-motd, reverted with


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

Change AL2 EOL date to past-tense.

Update AL2023 EOL date to 2029-06-30 to reflect latest date set in the docs, and add AL2023 support doc reference to the MOTD: https://docs.aws.amazon.com/linux/al2023/release-notes/support-info-by-support-statement.html#support-info-by-support-statement-eol

### Description for the changelog

housekeeping - AL2 Deprecation: update README and MOTD

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
