### PR TITLE
Pin ECS agent version on AL2 AMIs after EOL

### DIFF
--- a/al2.pkr.hcl
+++ b/al2.pkr.hcl
@@ -10,7 +10,7 @@ locals {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
-    ecs_agent_version   = "${var.ecs_agent_version}"
+    ecs_agent_version   = "${var.ecs_agent_version_al2}"
     ami_type            = "al2"
     ami_version         = "2.0.${var.ami_version_al2}"
   }
@@ -155,8 +155,8 @@ build {
     script = "scripts/install-ecs-init.sh"
     environment_vars = [
       "REGION=${var.region}",
-      "AGENT_VERSION=${var.ecs_agent_version}",
-      "INIT_REV=${var.ecs_init_rev}",
+      "AGENT_VERSION=${var.ecs_agent_version_al2}",
+      "INIT_REV=${var.ecs_init_rev_al2}",
       "AL_NAME=amzn2",
       "AIR_GAPPED=${var.air_gapped}",
       "ECS_INIT_URL=${var.ecs_init_url_al2}",

--- a/al2arm.pkr.hcl
+++ b/al2arm.pkr.hcl
@@ -4,7 +4,7 @@ locals {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
-    ecs_agent_version   = "${var.ecs_agent_version}"
+    ecs_agent_version   = "${var.ecs_agent_version_al2}"
     ami_type            = "al2arm"
     ami_version         = "2.0.${var.ami_version_al2}"
   }

--- a/al2gpu.pkr.hcl
+++ b/al2gpu.pkr.hcl
@@ -4,7 +4,7 @@ locals {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
-    ecs_agent_version   = "${var.ecs_agent_version}"
+    ecs_agent_version   = "${var.ecs_agent_version_al2}"
     ami_type            = "al2gpu"
     ami_version         = "2.0.${var.ami_version_al2}"
   }

--- a/al2inf.pkr.hcl
+++ b/al2inf.pkr.hcl
@@ -4,7 +4,7 @@ locals {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
-    ecs_agent_version   = "${var.ecs_agent_version}"
+    ecs_agent_version   = "${var.ecs_agent_version_al2}"
     ami_type            = "al2inf"
     ami_version         = "2.0.${var.ami_version_al2}"
   }

--- a/al2keplergpu.pkr.hcl
+++ b/al2keplergpu.pkr.hcl
@@ -4,7 +4,7 @@ locals {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
-    ecs_agent_version   = "${var.ecs_agent_version}"
+    ecs_agent_version   = "${var.ecs_agent_version_al2}"
     ami_type            = "al2keplergpu"
     ami_version         = "2.0.${var.ami_version_al2}"
   }

--- a/al2kernel5dot10.pkr.hcl
+++ b/al2kernel5dot10.pkr.hcl
@@ -4,7 +4,7 @@ locals {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
-    ecs_agent_version   = "${var.ecs_agent_version}"
+    ecs_agent_version   = "${var.ecs_agent_version_al2}"
     ami_type            = "al2kernel5dot10"
     ami_version         = "2.0.${var.ami_version_al2}"
   }

--- a/al2kernel5dot10arm.pkr.hcl
+++ b/al2kernel5dot10arm.pkr.hcl
@@ -4,7 +4,7 @@ locals {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
-    ecs_agent_version   = "${var.ecs_agent_version}"
+    ecs_agent_version   = "${var.ecs_agent_version_al2}"
     ami_type            = "al2kernel5dot10arm"
     ami_version         = "2.0.${var.ami_version_al2}"
   }

--- a/al2kernel5dot10gpu.pkr.hcl
+++ b/al2kernel5dot10gpu.pkr.hcl
@@ -4,7 +4,7 @@ locals {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
-    ecs_agent_version   = "${var.ecs_agent_version}"
+    ecs_agent_version   = "${var.ecs_agent_version_al2}"
     ami_type            = "al2kernel5dot10gpu"
     ami_version         = "2.0.${var.ami_version_al2}"
   }

--- a/al2kernel5dot10inf.pkr.hcl
+++ b/al2kernel5dot10inf.pkr.hcl
@@ -4,7 +4,7 @@ locals {
     os_version          = "Amazon Linux 2"
     source_image_name   = "{{ .SourceAMIName }}"
     ecs_runtime_version = "Docker version ${var.docker_version}"
-    ecs_agent_version   = "${var.ecs_agent_version}"
+    ecs_agent_version   = "${var.ecs_agent_version_al2}"
     ami_type            = "al2kernel5dot10inf"
     ami_version         = "2.0.${var.ami_version_al2}"
   }

--- a/generate-release-vars.sh
+++ b/generate-release-vars.sh
@@ -43,8 +43,10 @@ case "$ami_type" in
 
     readonly ami_name_al2_kernel5dot10arm ami_name_al2_kernel5dot10 ami_name_al2_arm ami_name_al2_x86
 
-    readonly ecs_agent_version=$(sed -n '/variable "ecs_agent_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
-    readonly ecs_init_rev=$(sed -n '/variable "ecs_init_rev" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    # AL2 is EOL. Its ECS agent version is pinned and read from the al2-specific
+    # variables so it no longer tracks the AL2023 agent version.
+    readonly ecs_agent_version=$(sed -n '/variable "ecs_agent_version_al2" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    readonly ecs_init_rev=$(sed -n '/variable "ecs_init_rev_al2" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
     readonly docker_version=$(sed -n '/variable "docker_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
     readonly containerd_version=$(sed -n '/variable "containerd_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
     readonly runc_version=$(sed -n '/variable "runc_version" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -94,26 +94,36 @@ set -e
 # Initialize update flag
 Update="false"
 
-# Check for NVIDIA driver version updates
-gpu_update=$(./scripts/check-update-security.sh "${ami_type}_gpu")
-handle_nvidia_version "$ami_type" "$gpu_update"
-# Only trigger update if GPU update detected AND NVIDIA_DRIVER_VERSION file actually changed
-if [[ $gpu_update == true* ]] && ! git diff --quiet NVIDIA_DRIVER_VERSION; then
-    Update="true"
-fi
-
-# Check for security updates if no dependency changes
-if [ -z "$diff_val" ]; then
-    # Check security updates for each architecture type
-    amd_update=$(./scripts/check-update-security.sh $ami_type)
-    arm_update=$(./scripts/check-update-security.sh "${ami_type}_arm")
-
-    # Combine results
-    if [[ $amd_update == true* ]] || [[ $arm_update == true* ]]; then
+if [ "$ami_type" = "al2" ]; then
+    # AL2 reached EOL on 2026-06-30. The ECS agent version is pinned and new ECS
+    # features are no longer supported on AL2. Per the EOL plan, AL2 AMIs are
+    # rebuilt only when a new base AMI is available from Amazon Linux. A new base
+    # AMI shows up as a source_ami_* change in diff_val, so gate the AL2 rebuild on that alone.
+    if [ -n "$diff_val" ]; then
         Update="true"
     fi
 else
-    Update="true"
+    # Check for NVIDIA driver version updates
+    gpu_update=$(./scripts/check-update-security.sh "${ami_type}_gpu")
+    handle_nvidia_version "$ami_type" "$gpu_update"
+    # Only trigger update if GPU update detected AND NVIDIA_DRIVER_VERSION file actually changed
+    if [[ $gpu_update == true* ]] && ! git diff --quiet NVIDIA_DRIVER_VERSION; then
+        Update="true"
+    fi
+
+    # Check for security updates if no dependency changes
+    if [ -z "$diff_val" ]; then
+        # Check security updates for each architecture type
+        amd_update=$(./scripts/check-update-security.sh $ami_type)
+        arm_update=$(./scripts/check-update-security.sh "${ami_type}_arm")
+
+        # Combine results
+        if [[ $amd_update == true* ]] || [[ $arm_update == true* ]]; then
+            Update="true"
+        fi
+    else
+        Update="true"
+    fi
 fi
 
 # Clean up temporary file

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -99,11 +99,13 @@ build_changelog_entry() {
         add_line "- al2023 ami version: ${DATE}"
     fi
 
-    # ECS version (only if changed)
-    local new_ecs="${new_ecs_version_al2:-$new_ecs_version_al2023}"
-    local old_ecs="${old_ecs_version_al2:-$old_ecs_version_al2023}"
-    if [ -n "$new_ecs" ] && [ "$new_ecs" != "$old_ecs" ]; then
-        add_line "- ecs version: ${new_ecs}"
+    # ECS version (only if changed). AL2 and AL2023 track independent agent
+    # versions (AL2 is pinned/EOL), so report each separately when it changes.
+    if [ -n "$new_ecs_version_al2" ] && [ "$new_ecs_version_al2" != "$old_ecs_version_al2" ]; then
+        add_line "- al2 ecs version: ${new_ecs_version_al2}"
+    fi
+    if [ -n "$new_ecs_version_al2023" ] && [ "$new_ecs_version_al2023" != "$old_ecs_version_al2023" ]; then
+        add_line "- al2023 ecs version: ${new_ecs_version_al2023}"
     fi
 
     # AL2 source AMIs (only changed ones)

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -47,13 +47,28 @@ variable "block_device_size_gb" {
 
 variable "ecs_agent_version" {
   type        = string
-  description = "ECS agent version to build AMI with."
+  description = "ECS agent version to build AL2023 AMI with."
   default     = "1.105.1"
 }
 
 variable "ecs_init_rev" {
   type        = string
-  description = "ecs-init package version rev"
+  description = "ecs-init package version rev for AL2023"
+  default     = "1"
+}
+
+# AL2 reached EOL on 2026-06-30. The ECS agent version is pinned on AL2 AMIs and
+# no longer tracks the AL2023 agent version. Do not bump these unless a new AL2
+# AMI is being built intentionally.
+variable "ecs_agent_version_al2" {
+  type        = string
+  description = "Pinned ECS agent version to build AL2 AMIs with (AL2 is EOL)."
+  default     = "1.105.1"
+}
+
+variable "ecs_init_rev_al2" {
+  type        = string
+  description = "Pinned ecs-init package version rev for AL2 (AL2 is EOL)."
   default     = "1"
 }
 


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->

AL2 reached EOL on 2026-06-30. New ECS features are no longer supported on AL2 and the ECS agent version is pinned. Previously AL2 and AL2023 shared a single ecs_agent_version variable, so any AL2023 agent bump automatically flowed into AL2. Decouple them following the docker_version pattern.

- Add pinned ecs_agent_version_al2 and ecs_init_rev_al2 variables; the existing ecs_agent_version/ecs_init_rev now belong to AL2023 and keep auto-updating.
- Point all AL2 recipes and the shared build provisioner at the pinned al2-specific variables.
- generate-release-vars.sh reads the pinned al2 variables for the al2 branch.
- check-update.sh rebuilds AL2 only on a new base AMI; security-only and GPU/NVIDIA-only updates no longer trigger AL2 builds. AL2023 unchanged.
- generate-changelog.sh reports al2 and al2023 ECS versions independently now that they can differ.

Assisted-by: Claude Code:claude-opus-4-8

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Testing

- verified `make validate` passes to ensure new al2 variable is present in all recipes
- updated `ecs_agent_version` and verified this doesnt generate a new diff for AL2
- ran `./scripts/check-update.sh al2` when there is and isnt an update to the base ami and verified correct output

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: feature, enhancement, bugfix, housekeeping

Examples:
- feature - Enable dynamic NVIDIA driver selection
- enhancement - Bump docker version to x.x.x
- bugfix - remove nvidia-persistenced from the installation list
- housekeeping - Fix bug in nvidia driver upgrade check command

Note: A PR check will fail if this section does not contain a changelog with a valid category keyword.

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

- housekeeping - AL2 Deprecation: pin agent version and only release AMIs on base AMI updates.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
