### PR TITLE
Refactor security check to tag NVIDIA drivers

### DIFF
--- a/scripts/check-update-security.sh
+++ b/scripts/check-update-security.sh
@@ -290,7 +290,7 @@ if [ "$platform" = "al2023_gpu" ]; then
         exit 0
     fi
 
-    echo "true $effective_version"
+    echo "true nvidia:$effective_version"
     exit 0
 fi
 
@@ -300,29 +300,13 @@ if [ "$cmd_response_code" -eq "$UPDATE_EXISTS_CODE" ]; then
         nvidia_driver_version=$(echo "$std_output" | grep "nvidia-driver-latest-dkms" | awk '{print $2}' | cut -d'-' -f1 | sed 's/^[0-9]://' || true)
         cuda_version=$(echo "$std_output" | grep "^cuda" | awk '{print $2}' | cut -d'-' -f1 | sed 's/^[0-9]://' || true)
 
-        # Determine output format based on available version combinations
-        version_pattern=""
-        [ -n "$nvidia_driver_version" ] && version_pattern="${version_pattern}nvidia"
-        [ -n "$cuda_version" ] && version_pattern="${version_pattern}_cuda"
-
-        case "$version_pattern" in
-        "nvidia_cuda")
-            # Both NVIDIA and CUDA updates available
-            echo "true $nvidia_driver_version $cuda_version"
-            ;;
-        "nvidia")
-            # Only NVIDIA driver update available
-            echo "true $nvidia_driver_version"
-            ;;
-        "_cuda")
-            # Only CUDA package update available
-            echo "true cuda:$cuda_version"
-            ;;
-        *)
-            # No specific versions detected, but updates exist
-            echo "true"
-            ;;
-        esac
+        # Emit each detected version as a tagged token (nvidia:/cuda:) so the
+        # caller can classify it by prefix regardless of order. If neither
+        # version is detected, emit a bare "true" to signal an update exists.
+        output="true"
+        [ -n "$nvidia_driver_version" ] && output="$output nvidia:$nvidia_driver_version"
+        [ -n "$cuda_version" ] && output="$output cuda:$cuda_version"
+        echo "$output"
     elif [ "$platform" = "al2023_gpu" ]; then
         # This path should not be reached; al2023_gpu is handled above via repoquery
         echo "ERROR: Unexpected al2023_gpu in check-upgrade result path"

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -45,7 +45,7 @@ handle_nvidia_version() {
         # Untagged tokens are ignored, so a bare "true" yields no versions (unlike
         # the old positional parser, which mis-read "true" as an nvidia version).
         local -a fields=()
-        read -ra fields <<< "${gpu_update#true}"
+       read -ra fields <<< "${gpu_update#true}"
         local field
         for field in "${fields[@]}"; do
             case "$field" in

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -45,7 +45,7 @@ handle_nvidia_version() {
         # Untagged tokens are ignored, so a bare "true" yields no versions (unlike
         # the old positional parser, which mis-read "true" as an nvidia version).
         local -a fields=()
-       read -ra fields <<< "${gpu_update#true}"
+        read -ra fields <<<"${gpu_update#true}"
         local field
         for field in "${fields[@]}"; do
             case "$field" in

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -32,20 +32,31 @@ handle_nvidia_version() {
     local cuda_version_key="cuda_version_${ami_variant}"
 
     if [[ $gpu_update == true* ]]; then
-        # Parse the output format: "true <nvidia_version> <cuda_version>" or "true <nvidia_version>" or "true cuda:<cuda_version>"
-        local update_info=$(echo "$gpu_update" | cut -d' ' -f2-)
-
-        # Check for both nvidia and cuda versions (space-separated)
-        if [[ $update_info == *" "* ]]; then
-            nvidia_version=$(echo "$update_info" | cut -d' ' -f1)
-            cuda_version=$(echo "$update_info" | cut -d' ' -f2)
-        # Check for cuda-only update
-        elif [[ $update_info == cuda:* ]]; then
-            cuda_version=$(echo "$update_info" | cut -d':' -f2)
-        # else nvidia version
-        else
-            nvidia_version="$update_info"
-        fi
+        # $gpu_update is check-update-security.sh's stdout, a single line. When a
+        # version is detected it is emitted as a tagged token; the producer only
+        # tags versions it actually found, so a bare "true" (no tokens) is valid
+        # and means "an update exists but no specific version was resolved". The
+        # possible shapes, in any token order:
+        #   "true"                                    (update exists, no version)
+        #   "true nvidia:<nvidia_version>"            (driver only)
+        #   "true nvidia:<...> cuda:<cuda_version>"   (al2_gpu, driver + cuda)
+        #   "true cuda:<cuda_version>"                (al2_gpu, cuda only)
+        # Read the fields after "true" and classify each strictly by its prefix.
+        # Untagged tokens are ignored, so a bare "true" yields no versions (unlike
+        # the old positional parser, which mis-read "true" as an nvidia version).
+        local -a fields=()
+        read -ra fields <<< "${gpu_update#true}"
+        local field
+        for field in "${fields[@]}"; do
+            case "$field" in
+            nvidia:*)
+                nvidia_version="${field#nvidia:}"
+                ;;
+            cuda:*)
+                cuda_version="${field#cuda:}"
+                ;;
+            esac
+        done
     fi
 
     # Update NVIDIA driver version entry if available


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Refactor security scripts to tag NVIDIA drivers. 

### Implementation details
<!-- How are the changes implemented? -->

Modified the following files:
- `scripts/check-update-security.sh`: add `nvidia` tag to all nvidia package outputs.
- `scripts/check-update.sh`: parse `check-update-security.sh` output based on tagged package versions. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Copied `handle_nvidia_version()` function from `check-update.sh` script into a new shell script, ran it with outputs from `check-update-security.sh` (e.g. `"true nvidia:580.161.00" 'nvidia_driver_version_al2023 = "580.161.00"'`) and confirmed that it works.

Also fixed a bug where for `al2_gpu` platform where we could encounter a package exists but then write `nvidia_driver_version_al2 = "true"` which corrupts the file. 

`check-update-security.sh` returns `true` for `al2_gpu` build which will then be written in `NVIDIA_DRIVER_VERSION` file.  

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: feature, enhancement, bugfix, housekeeping

Examples:
- feature - Enable dynamic NVIDIA driver selection
- enhancement - Bump docker version to x.x.x
- bugfix - remove nvidia-persistenced from the installation list
- housekeeping - Fix bug in nvidia driver upgrade check command

Note: A PR check will fail if this section does not contain a changelog with a valid category keyword.

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Housekeeping - refactor check-update scripts to tag NVIDIA drivers

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.