### PR TITLE
Revert "Add DCGM package security version check for AL2023 GPU AMIs

### DIFF
--- a/NVIDIA_DRIVER_VERSION
+++ b/NVIDIA_DRIVER_VERSION
@@ -5,14 +5,12 @@
 #
 # Format: nvidia_driver_version_<ami_type> = "<version>"
 #         cuda_version_<ami_type> = "<version>" (AL2 only)
-#         dcgm_version_<ami_type> = "<version>"
 #
-# This file tracks the latest NVIDIA driver, CUDA, and DCGM versions detected
-# for different Amazon Linux AMIs. For AL2023 GPU, the versions in this file
-# are used by install scripts during AMI builds (sourced via Packer file
-# provisioner). The pinned major versions are defined in variables.pkr.hcl.
+# This file tracks the latest NVIDIA driver and CUDA versions detected for
+# different Amazon Linux AMIs. For AL2023 GPU, the version in this file is
+# used by the install script during AMI builds (sourced via Packer file
+# provisioner). The pinned major version is defined in variables.pkr.hcl.
 
 nvidia_driver_version_al2 = "550.163.01"
 nvidia_driver_version_al2023 = "580.159.03"
 cuda_version_al2 = "12.4.1"
-dcgm_version_al2023 = "4.6.0"

--- a/al2023.pkr.hcl
+++ b/al2023.pkr.hcl
@@ -232,6 +232,7 @@ build {
 
   provisioner "shell" {
     environment_vars = [
+      "DCGM_VERSION=${var.dcgm_version_al2023}",
       "AIR_GAPPED=${var.air_gapped}"
     ]
     script = "scripts/al2023/gpu/install-dcgm.sh"

--- a/scripts/al2023/gpu/install-dcgm.sh
+++ b/scripts/al2023/gpu/install-dcgm.sh
@@ -7,29 +7,20 @@ if [ -n "$AIR_GAPPED" ]; then
     exit 0
 fi
 
-# dcgm-init ships in the amazon-ecs-init RPM; skip until it's present. Checks the
-# path directly since /usr/libexec is not on $PATH.
+# The dcgm-init binary (and its systemd unit) ships in the amazon-ecs-init RPM,
+# which is installed earlier in the build. Older RPMs don't include it yet, so
+# skip DCGM setup entirely until the binary is present (mirrors AIR_GAPPED).
+# Note: the binary lives in /usr/libexec, which is not on $PATH, so this checks
+# the install path directly rather than using `command -v`/`which`.
 if [ ! -f /usr/libexec/dcgm-init ]; then
     echo "dcgm-init binary not found, skipping DCGM installation"
     exit 0
 fi
 
-### Determine DCGM version, as selected by check-update-security.sh
-DCGM_FULL_VERSION=$(grep "^dcgm_version_al2023" /tmp/NVIDIA_DRIVER_VERSION | awk -F'"' '{print $2}')
-if [[ -z $DCGM_FULL_VERSION ]]; then
-    echo "ERROR: Could not read dcgm_version_al2023 from /tmp/NVIDIA_DRIVER_VERSION"
-    exit 1
-fi
-
-DCGM_MAJOR="${DCGM_FULL_VERSION%%.*}"
-echo "Using DCGM version: ${DCGM_FULL_VERSION}"
-
 ### Install DCGM core package (provides nv-hostengine and libdcgm.so)
-# Pinned to the exact version so the AMI matches what NVIDIA_DRIVER_VERSION
-# records.
-sudo dnf install -y "datacenter-gpu-manager-${DCGM_MAJOR}-core-${DCGM_FULL_VERSION}"
+sudo dnf install -y "datacenter-gpu-manager-${DCGM_VERSION}-core"
 
-### Lock DCGM packages to prevent automatic updates
+### Lock DCGM packages to prevent updates that could break the libdcgm.so ABI
 sudo dnf versionlock 'datacenter-gpu-manager*'
 
 ### Override nvidia-dcgm to use Unix domain socket instead of TCP

--- a/scripts/check-update-security.sh
+++ b/scripts/check-update-security.sh
@@ -92,22 +92,6 @@ case "$platform" in
     ;;
 esac
 
-# Read pinned major versions for AL2023 GPU filtering.
-nvidia_driver_pinned_major=""
-dcgm_pinned_major=""
-if [ "$platform" = "al2023_gpu" ]; then
-    nvidia_driver_pinned_major=$(sed -n '/variable "nvidia_driver_major_al2023" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
-    if [ -z "$nvidia_driver_pinned_major" ]; then
-        echo "ERROR: Could not read nvidia_driver_major_al2023 from variables.pkr.hcl"
-        exit 1
-    fi
-    dcgm_pinned_major=$(sed -n '/variable "dcgm_major_al2023" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
-    if [ -z "$dcgm_pinned_major" ]; then
-        echo "ERROR: Could not read dcgm_major_al2023 from variables.pkr.hcl"
-        exit 1
-    fi
-fi
-
 # Query ssm to get latest ecs optimized ami
 ami_id=$(aws ssm get-parameters --names $ami_path --region us-west-2 | jq -r '.Parameters[0].Value' | jq -r '.image_id')
 
@@ -157,6 +141,16 @@ instance_id=$(aws ec2 run-instances \
     --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value='$platform-check-update-security'}]' |
     jq -r '.Instances[0].InstanceId')
 
+# Read pinned major version for AL2023 GPU filtering
+nvidia_driver_pinned_major=""
+if [ "$platform" = "al2023_gpu" ]; then
+    nvidia_driver_pinned_major=$(sed -n '/variable "nvidia_driver_major_al2023" {/,/}/p' variables.pkr.hcl | grep "default" | awk -F '"' '{ print $2 }')
+    if [ -z "$nvidia_driver_pinned_major" ]; then
+        echo "ERROR: Could not read nvidia_driver_major_al2023 from variables.pkr.hcl"
+        exit 1
+    fi
+fi
+
 # check-update based on platform
 if [[ $platform == al2023* ]]; then
     check_upgrade_options="--sec-severity Critical --exclude=$EXCLUDE_SEC_UPDATES_PKGS"
@@ -166,11 +160,7 @@ if [[ $platform == al2023* ]]; then
         # version and all available within the pinned major, then intersect with GRID bucket locally.
         gpu_cmd_installed="dnf repoquery --installed --arch=x86_64 --queryformat '%{version}' nvidia-driver-cuda"
         gpu_cmd_all="dnf repoquery --releasever=latest --disableplugin=versionlock --arch=x86_64 --queryformat '%{version}' nvidia-driver-cuda | grep '^${nvidia_driver_pinned_major}[.]' | sort -V"
-        # Also query available DCGM versions within its pinned major. DCGM is not
-        # pre-installed on the base ECS GPU AMI, so there is no installed version to
-        # query; the current tracked version in NVIDIA_DRIVER_VERSION is the baseline.
-        dcgm_cmd_all="dnf repoquery --releasever=latest --disableplugin=versionlock --arch=x86_64 --queryformat '%{version}' datacenter-gpu-manager-${dcgm_pinned_major}-core | grep '^${dcgm_pinned_major}[.]' | sort -V"
-        command_params="commands=[\"echo INSTALLED=\$(${gpu_cmd_installed})\",\"echo REPO_VERSIONS=\$(${gpu_cmd_all} | paste -sd,)\",\"echo DCGM_REPO_VERSIONS=\$(${dcgm_cmd_all} | paste -sd,)\"]"
+        command_params="commands=[\"echo INSTALLED=\$(${gpu_cmd_installed})\",\"echo REPO_VERSIONS=\$(${gpu_cmd_all} | paste -sd,)\"]"
     else
         command_params="commands=[\"dnf --refresh check-upgrade --releasever=latest --disableplugin=versionlock $check_upgrade_options -q\"]"
     fi
@@ -264,20 +254,13 @@ if [ "$platform" = "al2023_gpu" ]; then
         exit 1
     fi
 
-    # `|| true` on each: grep exits 1 when the line is absent, which under
-    # `set -o pipefail` would abort the script before the explicit checks below
-    # could report a useful error. Let the assignments yield empty instead.
-    nvidia_driver_installed_version=$(echo "$std_output" | grep "^INSTALLED=" | cut -d'=' -f2 || true)
-    nvidia_driver_repo_versions_csv=$(echo "$std_output" | grep "^REPO_VERSIONS=" | cut -d'=' -f2 || true)
-    dcgm_repo_versions_csv=$(echo "$std_output" | grep "^DCGM_REPO_VERSIONS=" | cut -d'=' -f2 || true)
+    nvidia_driver_installed_version=$(echo "$std_output" | grep "^INSTALLED=" | cut -d'=' -f2)
+    nvidia_driver_repo_versions_csv=$(echo "$std_output" | grep "^REPO_VERSIONS=" | cut -d'=' -f2)
 
     if [ -z "$nvidia_driver_installed_version" ] || [ -z "$nvidia_driver_repo_versions_csv" ]; then
         echo "ERROR: Could not determine installed or available NVIDIA driver versions"
         exit 1
     fi
-
-    # DCGM isn't pre-installed, so use the version tracked in NVIDIA_DRIVER_VERSION
-    dcgm_installed_version=$(grep "^dcgm_version_al2023" NVIDIA_DRIVER_VERSION | awk -F'"' '{print $2}' || true)
 
     # Get all GRID bucket versions within pinned major
     grid_versions=$(aws s3 ls --recursive s3://ec2-linux-nvidia-drivers/ --no-sign-request |
@@ -301,47 +284,13 @@ if [ "$platform" = "al2023_gpu" ]; then
     fi
 
     # Only trigger a release if the effective version is newer than installed
-    dcgm_effective_version=$(echo "$dcgm_repo_versions_csv" | tr ',' '\n' | grep -v '^$' |
-        sort -V | tail -1 || true)
-
-    # Check if NVIDIA needs an update (effective strictly newer than installed)
-    nvidia_needs_update=false
     nvidia_driver_newer=$(printf '%s\n%s' "$nvidia_driver_installed_version" "$nvidia_driver_effective_version" | sort -V | tail -1)
-    [ "$nvidia_driver_newer" != "$nvidia_driver_installed_version" ] && nvidia_needs_update=true
-
-    # Check if DCGM needs an update. If no DCGM version is available in the repo
-    # (transient repo issue, major not yet published), skip DCGM rather than failing
-    # the whole check, so NVIDIA driver detection still proceeds. If a version is
-    # available but nothing is tracked yet, record it (first-time tracking).
-    # Otherwise, update only when the available version is strictly newer.
-    dcgm_needs_update=false
-    if [ -z "$dcgm_effective_version" ]; then
-        echo "WARNING: No DCGM version found in repo for major ${dcgm_pinned_major}; skipping DCGM update check" >&2
-    elif [ -z "$dcgm_installed_version" ]; then
-        dcgm_needs_update=true
-    else
-        dcgm_newer=$(printf '%s\n%s' "$dcgm_installed_version" "$dcgm_effective_version" | sort -V | tail -1)
-        [ "$dcgm_newer" != "$dcgm_installed_version" ] && dcgm_needs_update=true
-    fi
-
-    if [ "$nvidia_needs_update" = false ] && [ "$dcgm_needs_update" = false ]; then
+    if [ "$nvidia_driver_newer" = "$nvidia_driver_installed_version" ]; then
         echo "false"
         exit 0
     fi
 
-    # Output format: "true [nvidia:<nvidia_version>] [dcgm:<dcgm_version>]".
-    # Each version is emitted as a tagged token so the caller can classify it by
-    # prefix regardless of order. Only emit the NVIDIA version when NVIDIA actually
-    # needs an update, otherwise the caller would rewrite the tracked driver
-    # version (possibly a downgrade).
-    output="true"
-    if [ "$nvidia_needs_update" = true ]; then
-        output="$output nvidia:$nvidia_driver_effective_version"
-    fi
-    if [ "$dcgm_needs_update" = true ]; then
-        output="$output dcgm:$dcgm_effective_version"
-    fi
-    echo "$output"
+    echo "true nvidia:$nvidia_driver_effective_version"
     exit 0
 fi
 

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -28,10 +28,8 @@ handle_nvidia_version() {
 
     local nvidia_version=""
     local cuda_version=""
-    local dcgm_version=""
     local nvidia_version_key="nvidia_driver_version_${ami_variant}"
     local cuda_version_key="cuda_version_${ami_variant}"
-    local dcgm_version_key="dcgm_version_${ami_variant}"
 
     if [[ $gpu_update == true* ]]; then
         # $gpu_update is check-update-security.sh's stdout, a single line. When a
@@ -43,9 +41,6 @@ handle_nvidia_version() {
         #   "true nvidia:<nvidia_version>"            (driver only)
         #   "true nvidia:<...> cuda:<cuda_version>"   (al2_gpu, driver + cuda)
         #   "true cuda:<cuda_version>"                (al2_gpu, cuda only)
-        #   "true nvidia:<...> dcgm:<dcgm_version>"   (al2023_gpu, driver + dcgm)
-        # cuda: (al2_gpu) and dcgm: (al2023_gpu) come from different platforms and
-        # never appear together in one output.
         # Read the fields after "true" and classify each strictly by its prefix.
         # Untagged tokens are ignored, so a bare "true" yields no versions (unlike
         # the old positional parser, which mis-read "true" as an nvidia version).
@@ -59,9 +54,6 @@ handle_nvidia_version() {
                 ;;
             cuda:*)
                 cuda_version="${field#cuda:}"
-                ;;
-            dcgm:*)
-                dcgm_version="${field#dcgm:}"
                 ;;
             esac
         done
@@ -81,15 +73,6 @@ handle_nvidia_version() {
         if grep -q "^${cuda_version_key} = " NVIDIA_DRIVER_VERSION; then
             if ! sed -i "s/^${cuda_version_key} = .*/${cuda_version_key} = \"${cuda_version}\"/" NVIDIA_DRIVER_VERSION; then
                 echo "Failed to update CUDA version in NVIDIA_DRIVER_VERSION file"
-            fi
-        fi
-    fi
-
-    # Update DCGM version entry if available (AL2023 only)
-    if [ -n "$dcgm_version" ] && [ "$ami_variant" = "al2023" ]; then
-        if grep -q "^${dcgm_version_key} = " NVIDIA_DRIVER_VERSION; then
-            if ! sed -i "s/^${dcgm_version_key} = .*/${dcgm_version_key} = \"${dcgm_version}\"/" NVIDIA_DRIVER_VERSION; then
-                echo "Failed to update DCGM version in NVIDIA_DRIVER_VERSION file"
             fi
         fi
     fi

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -265,8 +265,8 @@ variable "nvidia_driver_major_al2023" {
   default     = "580"
 }
 
-variable "dcgm_major_al2023" {
+variable "dcgm_version_al2023" {
   type        = string
-  description = "Pinned DCGM major version for AL2023 GPU AMIs. Only versions within this major will be installed."
+  description = "DCGM major version for AL2023 GPU AMIs. Used to install the datacenter-gpu-manager-4-core package."
   default     = "4"
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This reverts commit bfa4c5e863d3fb3678bd76661612bd7d87bdc306.

### Implementation details
<!-- How are the changes implemented? -->

`git revert bfa4c5e863d3fb3678bd76661612bd7d87bdc306`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: feature, enhancement, bugfix, housekeeping

Examples:
- feature - Enable dynamic NVIDIA driver selection
- enhancement - Bump docker version to x.x.x
- bugfix - remove nvidia-persistenced from the installation list
- housekeeping - Fix bug in nvidia driver upgrade check command

Note: A PR check will fail if this section does not contain a changelog with a valid category keyword.

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Housekeeping - Revert DCGM package security check automation. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
