### PR TITLE
Move the MPS pipe directory off the default path

### DIFF
--- a/scripts/al2023/gpu/nvidia-mps.service
+++ b/scripts/al2023/gpu/nvidia-mps.service
@@ -8,6 +8,7 @@ ConditionPathExists=/usr/bin/nvidia-cuda-mps-control
 
 [Service]
 Type=exec
+Environment=CUDA_MPS_PIPE_DIRECTORY=/run/mps-ecs
 ExecStart=/usr/bin/nvidia-cuda-mps-control -f -multiuser-server
 Restart=always
 RestartSec=1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
`nvidia-mps.service` starts the MPS control daemon on the default pipe directory, `/tmp/nvidia-mps`. That path is not inert: CUDA probes it during initialization whether or not an application asked for MPS, since the NVIDIA container runtime bind-mounts it into every GPU container when it exists.
### Implementation details
<!-- How are the changes implemented? -->
Adding  `Environment=CUDA_MPS_PIPE_DIRECTORY=/run/mps-ecs` changes the default pipe directory from `/tmp/nvidia-mps` to `/run/mps-ecs` thus workloads that don't ask for MPS do not get the pipe directory mounted by default.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Baked an AL2023 GPU AMI with only this change:
* Daemon logs `Starting control daemon using socket /run/mps-ecs/control`.
* A plain GPU container sees the full physical GPU and never appears in the daemon log
* MPS clients pointed at the new path still attach and have their per-client `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT` enforced, including two concurrent clients on one GPU with independent caps.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: feature, enhancement, bugfix, housekeeping

Examples:
- feature - Enable dynamic NVIDIA driver selection
- enhancement - Bump docker version to x.x.x
- bugfix - remove nvidia-persistenced from the installation list
- housekeeping - Fix bug in nvidia driver upgrade check command

Note: A PR check will fail if this section does not contain a changelog with a valid category keyword.

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
bugfix - Move the NVIDIA MPS daemon off the default pipe directory
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
